### PR TITLE
[fixbug] modify nkn path in glide.yaml

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: nkn
+package: github.com/nknorg/nkn
 import:
 - package: github.com/golang/crypto
   subpackages:


### PR DESCRIPTION
1. move nkn to github/nknorg/nkn to avoid warning message.

Signed-off-by: NoelBright <noel.n.bright@gmail.com>