### PR TITLE
Add RPC API for Commit transaction

### DIFF
--- a/helper/TransactionHelper.go
+++ b/helper/TransactionHelper.go
@@ -239,3 +239,17 @@ func MakeWithdrawTransaction(wallet wallet.Wallet, assetID Uint256, value string
 
 	return txn, nil
 }
+
+func MakeCommitTransaction(wallet wallet.Wallet, sigChain []byte) (*transaction.Transaction, error) {
+	txn, err := transaction.NewCommitTransaction(sigChain)
+	if err != nil {
+		return nil, err
+	}
+
+	// sign transaction contract
+	ctx := contract.NewContractContext(txn)
+	wallet.Sign(ctx)
+	txn.SetPrograms(ctx.GetPrograms())
+
+	return txn, nil
+}

--- a/rpc/httpjson/RPCserver.go
+++ b/rpc/httpjson/RPCserver.go
@@ -28,13 +28,13 @@ func StartRPCServer() {
 	HandleFunc("getnodestate", getNodeState)
 	HandleFunc("getbalance", getBalance)
 
-
 	HandleFunc("setdebuginfo", setDebugInfo)
 	HandleFunc("setdebuginfo", sendToAddress)
 	HandleFunc("registasset", registAsset)
 	HandleFunc("issueasset", issueAsset)
 	HandleFunc("prepaidasset", prepaidAsset)
 	HandleFunc("withdrawasset", withdrawAsset)
+	HandleFunc("commitpor", commitPor)
 
 	err := http.ListenAndServe(LocalHost+":"+strconv.Itoa(config.Parameters.HttpJsonPort), nil)
 	if err != nil {

--- a/rpc/httpjson/interfaces.go
+++ b/rpc/httpjson/interfaces.go
@@ -544,3 +544,38 @@ func withdrawAsset(params []interface{}) map[string]interface{} {
 	txHash := txn.Hash()
 	return RpcResult(BytesToHexString(txHash.ToArrayReverse()))
 }
+
+func commitPor(params []interface{}) map[string]interface{} {
+	if len(params) < 1 {
+		return RpcResultNil
+	}
+
+	var sigChain []byte
+	var err error
+	switch params[0].(type) {
+	case string:
+		str := params[0].(string)
+		sigChain, err = HexStringToBytes(str)
+		if err != nil {
+			return RpcResultInvalidParameter
+		}
+	default:
+		return RpcResultInvalidParameter
+	}
+
+	if Wallet == nil {
+		return RpcResult("open wallet first")
+	}
+
+	txn, err := helper.MakeCommitTransaction(Wallet, sigChain)
+	if err != nil {
+		return RpcResultInternalError
+	}
+
+	if errCode := VerifyAndSendTx(txn); errCode != ErrNoError {
+		return RpcResultInvalidTransaction
+	}
+
+	txHash := txn.Hash()
+	return RpcResult(BytesToHexString(txHash.ToArrayReverse()))
+}


### PR DESCRIPTION
Add JsonRPC API for creating and sending Commint transaction.
This API can be used to broadcast the PoR of nodes by clients.

Signed-off-by: NoelBright <noel.n.bright@gmail.com>