### PR TITLE
[Bugfix] os.Rename can't work between different partitions. Changed os.Rename to exec.Command("mv') for better fault-tolerant.

### DIFF
--- a/wallet/store.go
+++ b/wallet/store.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"sync"
 
@@ -109,7 +110,7 @@ func (p *Store) write(data []byte) error {
 		err = permErr
 	}
 	if err == nil {
-		err = os.Rename(f.Name(), name)
+		err = exec.Command("mv", "-f", f.Name(), name).Run()
 	}
 	if err != nil {
 		os.Remove(f.Name())


### PR DESCRIPTION
[Bugfix] os.Rename can't work between different partitions.
Changed os.Rename to exec.Command("mv') for better fault-tolerant.
Ref: https://groups.google.com/forum/#!topic/golang-dev/5w7Jmg_iCJQ
Bug desc: On my OS env, $TMP is a tmpfs and $PWD is a xda storage.
os.Rename will thrown err when move /tmp/wallte.dat to ./