### PR TITLE
[bugfix] generate different genesis block when BookKeeper not configured

### DIFF
--- a/core/ledger/block.go
+++ b/core/ledger/block.go
@@ -157,11 +157,6 @@ func (b *Block) Type() InventoryType {
 }
 
 func GenesisBlockInit(defaultBookKeeper []*crypto.PubKey) (*Block, error) {
-	//getBookKeeper
-	nextBookKeeper, err := GetBookKeeperAddress(defaultBookKeeper)
-	if err != nil {
-		return nil, NewDetailErr(err, ErrNoCode, "[Block],GenesisBlockInit err with GetBookKeeperAddress")
-	}
 	//blockdata
 	genesisBlockdata := &Header{
 		Version:          BlockVersion,
@@ -170,7 +165,7 @@ func GenesisBlockInit(defaultBookKeeper []*crypto.PubKey) (*Block, error) {
 		Timestamp:        uint32(uint32(time.Date(2017, time.February, 23, 0, 0, 0, 0, time.UTC).Unix())),
 		Height:           uint32(0),
 		ConsensusData:    GenesisNonce,
-		NextBookKeeper:   nextBookKeeper,
+		NextBookKeeper:   Uint160{},
 		Program: &program.Program{
 			Code:      []byte{},
 			Parameter: []byte{byte(vm.PUSHT)},


### PR DESCRIPTION
When BookKeeper is not configured in config.json. Different node will generate different genesis block, then block producing will fail.

Signed-off-by: oscar <oscar@nkn.org>