### PR TITLE
Use second last node as ledger node to prevent selecting client

### DIFF
--- a/consensus/ising/proposerservice.go
+++ b/consensus/ising/proposerservice.go
@@ -114,7 +114,7 @@ func (ps *ProposerService) ProposerRoutine(vType voting.VotingContentType) {
 		sigchain := &por.SigChain{}
 		proto.Unmarshal(payload.SigChain, sigchain)
 		// TODO: get a determinate public key on signature chain
-		pbk, err := sigchain.GetLastPubkey()
+		pbk, err := sigchain.GetLedgerNodePubkey()
 		if err != nil {
 			log.Warn("Get last public key error", err)
 			return

--- a/por/sigchain.go
+++ b/por/sigchain.go
@@ -353,7 +353,19 @@ func (sc *SigChain) GetLastPubkey() ([]byte, error) {
 		return nil, err
 	}
 	return e.NextPubkey, nil
+}
 
+func (sc *SigChain) GetLedgerNodePubkey() ([]byte, error) {
+	if !sc.IsFinal() {
+		return nil, errors.New("not final")
+	}
+
+	n := sc.Length()
+	if n < 3 {
+		return nil, errors.New("not enough elements")
+	}
+
+	return sc.Elems[n-3].NextPubkey, nil
 }
 
 func (sc *SigChain) nextSigner() ([]byte, error) {


### PR DESCRIPTION
Use second last node as ledger node to prevent selecting client