### PR TITLE
Add go report and travis tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Go Report Card](https://goreportcard.com/badge/github.com/nknorg/nkn)](https://goreportcard.com/report/github.com/nknorg/nkn)
+[![Build Status](https://travis-ci.org/nknorg/nkn.svg?branch=master)](https://travis-ci.org/nknorg/nkn)
+
 [![NKN](https://github.com/nknorg/nkn/wiki/img/nkn_logo.png)](https://nkn.org)
 
 # NKN: a Scalable Self-Evolving and Self-Incentivized Decentralized Network


### PR DESCRIPTION
Added 'go report' tag for code quality.
Added 'travis' tag for code building.

These tags will work after open source.

See details on page: #https://github.com/doraemon0/nkn/tree/tag 

Signed-off-by: oscar <oscar@nkn.org>