### PR TITLE
Host GoReportCard on nkn.org server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Go Report Card](https://goreportcard.com/badge/github.com/nknorg/nkn)](https://goreportcard.com/report/github.com/nknorg/nkn)
+[![Go Report Card](https://nkn.org/badge/nkn.svg)](https://goreportcard.com/report/github.com/nknorg/nkn)
 [![Build Status](https://travis-ci.org/nknorg/nkn.svg?branch=master)](https://travis-ci.org/nknorg/nkn)
 
 [![NKN](https://github.com/nknorg/nkn/wiki/img/nkn_logo.png)](https://nkn.org)


### PR DESCRIPTION
The GoReportCard in README.md displayed abnormally on github. Shows "go report error" sometimes.

After asked help for GoReportCard team:
https://github.com/gojp/goreportcard/issues/250

We would host the badge on nkn.org to workaround this first.

Signed-off-by: oscar <oscar@nkn.org>