### PR TITLE
Need to do vote counting for requested block and sigchain

### DIFF
--- a/consensus/ising/voting/sigchain.go
+++ b/consensus/ising/voting/sigchain.go
@@ -127,7 +127,6 @@ func (scv *SigChainVoting) GetBestVotingContent(height uint32) (VotingContent, e
 	}
 
 	return nil, errors.New("invalid commit transaction")
-
 }
 
 func (scv *SigChainVoting) GetWorseVotingContent(height uint32) (VotingContent, error) {
@@ -144,27 +143,13 @@ func (scv *SigChainVoting) GetVotingContentFromPool(hash Uint256, height uint32)
 }
 
 func (scv *SigChainVoting) GetVotingContent(hash Uint256, height uint32) (VotingContent, error) {
-	// get signature chain by height and hash
-	sigChain, err := scv.porServer.GetSigChain(height, hash)
-	if err != nil {
-		return nil, err
-	}
-	sigHash, err := sigChain.SignatureHash()
-	if err != nil {
-		return nil, err
-	}
-	// get transaction hash by signature chain
-	txnHash, exist := scv.porServer.IsSigChainExist(sigHash, height)
-	if !exist {
-		return nil, errors.New("signature chain doesn't exist")
-	}
 	// get transaction from transaction pool
-	txnInPool := scv.txnCollector.GetTransaction(*txnHash)
+	txnInPool := scv.txnCollector.GetTransaction(hash)
 	if txnInPool != nil {
 		return txnInPool, nil
 	}
 	// get transaction from ledger
-	txnInLedger, err := ledger.DefaultLedger.Store.GetTransaction(*txnHash)
+	txnInLedger, err := ledger.DefaultLedger.Store.GetTransaction(hash)
 	if err == nil {
 		return txnInLedger, nil
 	}


### PR DESCRIPTION
When nodes receive response from requested neighbors, votes should
be calculated also. This will make new node joining more smoothly.

Also done together:
1. run proposal sending and voting concurrently
2. cleanup transactions when block persisted finished

Signed-off-by: oscar <oscar@nkn.org>