### PR TITLE
improvements for block syncing

### DIFF
--- a/common/uint256.go
+++ b/common/uint256.go
@@ -12,6 +12,8 @@ import (
 
 const UINT256SIZE = 32
 
+var EmptyUint256 Uint256
+
 type Uint256 [UINT256SIZE]uint8
 
 func (u *Uint256) CompareTo(o Uint256) int {

--- a/db/store.go
+++ b/db/store.go
@@ -1148,7 +1148,7 @@ func (cs *ChainStore) persistBlocks(ledger *Ledger) {
 		cs.mu.Unlock()
 
 		ledger.Blockchain.BCEvents.Notify(events.EventBlockPersistCompleted, block)
-		log.Debugf("current block height: %d, block hash: %x", block.Header.Height, hash.ToArrayReverse())
+		log.Infof("# current block height: %d, block hash: %x", block.Header.Height, hash.ToArrayReverse())
 	}
 
 }

--- a/net/chord/chord.go
+++ b/net/chord/chord.go
@@ -284,12 +284,9 @@ func CreateNet() (*Ring, *TCPTransport, error) {
 	ring = r
 
 	go func() {
-		i := 0
 		for {
 			time.Sleep(20 * time.Second)
-			log.Infof("Create Height = %d\n", i)
 			r.DumpInfo(false)
-			i++
 		}
 	}()
 
@@ -328,12 +325,9 @@ func JoinNet() (*Ring, *TCPTransport, error) {
 	ring = r
 
 	go func() {
-		i := 0
 		for {
 			time.Sleep(20 * time.Second)
-			log.Infof("Join Height = %d\n", i)
 			r.DumpInfo(false)
-			i++
 		}
 	}()
 

--- a/net/chord/ring.go
+++ b/net/chord/ring.go
@@ -10,16 +10,16 @@ import (
 
 func (r *Ring) DumpInfo(finger bool) {
 	for idx, vnode := range r.Vnodes {
-		log.Infof("ring.Vnodes[%d]: {", idx)
-		log.Infof("\tId: %x", string(vnode.Id))
-		log.Infof("\tHost: %s", vnode.Host)
+		log.Debugf("ring.Vnodes[%d]: {", idx)
+		log.Debugf("\tId: %x", string(vnode.Id))
+		log.Debugf("\tHost: %s", vnode.Host)
 
 		for sidx, succ := range vnode.successors {
 			if succ != nil {
-				log.Infof("\tsucc[%d].Id: %x", sidx, string(succ.Id))
-				log.Infof("\tsucc[%d].Host: %s", sidx, succ.Host)
+				log.Debugf("\tsucc[%d].Id: %x", sidx, string(succ.Id))
+				log.Debugf("\tsucc[%d].Host: %s", sidx, succ.Host)
 			} else {
-				log.Infof("\tsucc[%d]: nil", sidx)
+				log.Debugf("\tsucc[%d]: nil", sidx)
 			}
 		}
 
@@ -27,21 +27,21 @@ func (r *Ring) DumpInfo(finger bool) {
 		if finger {
 			for fidx, fing := range vnode.finger {
 				if fing != nil {
-					log.Infof("\tfinger[%d].Id: %x", fidx, string(fing.Id))
-					log.Infof("\tfinger[%d].Host: %s", fidx, fing.Host)
+					log.Debugf("\tfinger[%d].Id: %x", fidx, string(fing.Id))
+					log.Debugf("\tfinger[%d].Host: %s", fidx, fing.Host)
 				} else {
-					log.Infof("\tfinger[%d]: nil", fidx)
+					log.Debugf("\tfinger[%d]: nil", fidx)
 				}
 			}
 		}
 
-		log.Infof("\tlast_finger: %d", vnode.last_finger)
+		log.Debugf("\tlast_finger: %d", vnode.last_finger)
 		if vnode.predecessor != nil {
-			log.Infof("\tpredecessor.Id: %x", string((*vnode.predecessor).Id))
-			log.Infof("\tpredecessor.Host: %s", (*vnode.predecessor).Host)
+			log.Debugf("\tpredecessor.Id: %x", string((*vnode.predecessor).Id))
+			log.Debugf("\tpredecessor.Host: %s", (*vnode.predecessor).Host)
 		}
-		log.Infof("\tstabilized: %s", vnode.stabilized.String())
-		log.Infof("}\n")
+		log.Debugf("\tstabilized: %s", vnode.stabilized.String())
+		log.Debugf("}\n")
 	}
 }
 

--- a/net/message/blockHdr.go
+++ b/net/message/blockHdr.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"io"
 
-	"github.com/nknorg/nkn/common"
+	. "github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/common/serialization"
 	"github.com/nknorg/nkn/core/ledger"
 	. "github.com/nknorg/nkn/net/protocol"
@@ -29,7 +29,7 @@ type blkHeader struct {
 	blkHdr []ledger.Header
 }
 
-func NewHeadersReq(stopHash common.Uint256) ([]byte, error) {
+func NewHeadersReq(stopHash Uint256) ([]byte, error) {
 	var h headersReq
 
 	h.p.len = 1
@@ -166,7 +166,7 @@ func (msg headersReq) Handle(node Noder) error {
 	return nil
 }
 
-func SendMsgSyncHeaders(node Noder, stopHash common.Uint256) {
+func SendMsgSyncHeaders(node Noder, stopHash Uint256) {
 	buf, err := NewHeadersReq(stopHash)
 	if err != nil {
 		log.Error("failed build a new headersReq")
@@ -184,13 +184,12 @@ func (msg blkHeader) Handle(node Noder) error {
 	return nil
 }
 
-func GetHeadersFromHash(startHash common.Uint256, stopHash common.Uint256) ([]ledger.Header, uint32, error) {
+func GetHeadersFromHash(startHash Uint256, stopHash Uint256) ([]ledger.Header, uint32, error) {
 	var count uint32 = 0
-	var empty [HashLen]byte
 	headers := []ledger.Header{}
 	var startHeight uint32
 	var stopHeight uint32
-	if startHash == empty {
+	if startHash == EmptyUint256 {
 		return nil, 0, errors.New("invalid start hash for getting headers")
 	}
 	// get start height
@@ -201,7 +200,7 @@ func GetHeadersFromHash(startHash common.Uint256, stopHash common.Uint256) ([]le
 	startHeight = bkstart.Height
 
 	// get stop height
-	if stopHash == empty {
+	if stopHash == EmptyUint256 {
 		stopHeight = ledger.DefaultLedger.Store.GetHeaderHeight()
 	} else {
 		bkstop, err := ledger.DefaultLedger.Store.GetHeader(stopHash)

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -53,8 +53,8 @@ type Noder interface {
 	GetSyncState() SyncState
 	SetSyncState(s SyncState)
 	SetSyncStopHash(hash Uint256, height uint32)
-	SyncBlock()
-	SyncBlockMonitor()
+	SyncBlock(bool)
+	SyncBlockMonitor(bool)
 	GetRelay() bool
 	GetPubKey() *crypto.PubKey
 	CompareAndSetState(old, new uint32) bool


### PR DESCRIPTION
1. non-proposer node waits for first block flooding message to
start syncing.
2. if proposer node is lower than neighbors, sync the longest
chain first.
3. wait for syncing finished then start consensus
4. optimizing log

Signed-off-by: oscar <oscar@nkn.org>