### PR TITLE
voting for cached blocks when sync block

### DIFF
--- a/consensus/ising/synccache.go
+++ b/consensus/ising/synccache.go
@@ -1,43 +1,59 @@
 package ising
 
 import (
-	"sync"
-
 	"errors"
+	"sync"
+	"time"
+
 	. "github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/core/ledger"
+	"github.com/nknorg/nkn/util/log"
 )
+
+// BlockWithVotes describes cached block with vote count got from neighbors.
+type BlockWithVotes struct {
+	block           *ledger.Block // cached block
+	voters          []uint64      // block voter ID
+	totalVoterCount int           // total voter count when receive block
+	isMostVoted     bool          // whether this block get most votes
+}
+
+// CacheItem cached blocks for same height
+type CacheItem struct {
+	blocksWithVote []*BlockWithVotes // cached block with votes
+	timeLocker     *time.Timer       // time locker for block, block could be used after it expired
+}
 
 // SyncCache cached blocks sent by block proposer when wait for block syncing finished.
 type SyncCache struct {
 	sync.RWMutex
 	minHeight uint32
 	maxHeight uint32
-	cache     map[uint32][]*ledger.Block
+	cache     map[uint32]*CacheItem
 }
 
 func NewSyncBlockCache() *SyncCache {
 	return &SyncCache{
 		minHeight: 0,
 		maxHeight: 0,
-		cache:     make(map[uint32][]*ledger.Block),
+		cache:     make(map[uint32]*CacheItem),
 	}
 }
 
-// BlockInSyncCache returns whether the block exists in cache pool.
-func (sc *SyncCache) BlockInSyncCache(hash Uint256, height uint32) bool {
+// BlockInSyncCache returns the block with voters and true if it exists in cache.
+func (sc *SyncCache) BlockInSyncCache(hash Uint256, height uint32) (*BlockWithVotes, bool) {
 	sc.RLock()
 	defer sc.RUnlock()
 
-	if blocks, ok := sc.cache[height]; ok {
-		for _, b := range blocks {
-			if hash.CompareTo(b.Hash()) == 0 {
-				return true
+	if item, ok := sc.cache[height]; ok {
+		for _, b := range item.blocksWithVote {
+			if hash.CompareTo(b.block.Hash()) == 0 {
+				return b, true
 			}
 		}
 	}
 
-	return false
+	return nil, false
 }
 
 // CachedBlockHeight returns cached block height.
@@ -48,27 +64,43 @@ func (sc *SyncCache) CachedBlockHeight() int {
 	return len(sc.cache)
 }
 
-// GetBlockFromSyncCache returns cached block which height is minimum.
+// GetBlockFromSyncCache returns cached block which height is minimum and its vote count.
 func (sc *SyncCache) GetBlockFromSyncCache() *ledger.Block {
 	sc.RLock()
 	defer sc.RUnlock()
 
-	if blocks, ok := sc.cache[sc.minHeight]; !ok {
+	item, ok := sc.cache[sc.minHeight]
+	if !ok {
 		return nil
-	} else {
-		if len(blocks) == 0 {
+	}
+	if len(item.blocksWithVote) == 0 {
+		return nil
+	}
+	select {
+	case <-item.timeLocker.C:
+		item.timeLocker.Reset(0)
+		var mostVotesBlock *BlockWithVotes
+		for _, v := range item.blocksWithVote {
+			if v.isMostVoted {
+				mostVotesBlock = v
+				break
+			}
+		}
+		if mostVotesBlock == nil {
+			log.Error("inconsistent block voting for height: ", sc.minHeight)
 			return nil
 		}
-		// TODO: return block which got enough votes
-		return blocks[0]
+
+		return mostVotesBlock.block
 	}
 }
 
-// AddBlockToSyncCache add received block to cache. Returns nil if block already existed.
-func (sc *SyncCache) AddBlockToSyncCache(block *ledger.Block) error {
+// AddBlockToSyncCache caches received block and the voter count when receive block.
+// Returns nil if block already existed.
+func (sc *SyncCache) AddBlockToSyncCache(block *ledger.Block, totalVoterCount int) error {
 	hash := block.Hash()
 	blockHeight := block.Header.Height
-	if sc.BlockInSyncCache(hash, blockHeight) {
+	if _, exist := sc.BlockInSyncCache(hash, blockHeight); exist {
 		return nil
 	}
 
@@ -83,7 +115,15 @@ func (sc *SyncCache) AddBlockToSyncCache(block *ledger.Block) error {
 		}
 		sc.maxHeight++
 	}
-	sc.cache[blockHeight] = append(sc.cache[blockHeight], block)
+	zeroVoteBlock := &BlockWithVotes{
+		block:           block,
+		voters:          nil,
+		totalVoterCount: totalVoterCount,
+		isMostVoted:     false,
+	}
+	sc.cache[blockHeight] = new(CacheItem)
+	sc.cache[blockHeight].timeLocker = time.NewTimer(WaitingForVotingFinished)
+	sc.cache[blockHeight].blocksWithVote = append(sc.cache[blockHeight].blocksWithVote, zeroVoteBlock)
 
 	return nil
 }
@@ -93,11 +133,69 @@ func (sc *SyncCache) RemoveBlockFromCache() error {
 	sc.Lock()
 	defer sc.Unlock()
 
-	if _, ok := sc.cache[sc.minHeight]; !ok {
+	if item, ok := sc.cache[sc.minHeight]; !ok {
 		return nil
+	} else {
+		item.timeLocker.Stop()
 	}
 	delete(sc.cache, sc.minHeight)
 	sc.minHeight++
+
+	return nil
+}
+
+// AddVoteForBlock adds vote for a block when receive valid proposal.
+func (sc *SyncCache) AddVoteForBlock(hash Uint256, height uint32, voter uint64) error {
+	if b, exist := sc.BlockInSyncCache(hash, height); !exist {
+		return errors.New("voted block doesn't exist")
+	} else {
+		b.voters = append(b.voters, voter)
+		if 2*len(b.voters) > b.totalVoterCount {
+			log.Infof("got enough votes for block %s in syncing (%d votes / %d neighbors)",
+				BytesToHexString(hash.ToArrayReverse()), len(b.voters), b.totalVoterCount)
+			b.isMostVoted = true
+		}
+	}
+
+	return nil
+}
+
+// ChangeVoteForBlock change vote for a block when mind changed.
+func (sc *SyncCache) ChangeVoteForBlock(hash Uint256, height uint32, voter uint64) error {
+	b, exist := sc.BlockInSyncCache(hash, height)
+	if !exist {
+		return errors.New("voted block doesn't exist when change vote")
+	}
+	item, ok := sc.cache[height]
+	if !ok {
+		return errors.New("voted block height doesn't exist when change vote")
+	}
+	// remove previous vote
+	found := false
+	for _, b := range item.blocksWithVote {
+		for i, v := range b.voters {
+			if v == voter {
+				found = true
+				b.voters = append(b.voters[0:i], b.voters[i+1:]...)
+				if 2*len(b.voters) <= b.totalVoterCount && b.isMostVoted {
+					log.Infof("got insufficient votes for block %s after changing mind"+
+						" (%d votes / %d neighbors)", BytesToHexString(hash.ToArrayReverse()),
+						len(b.voters), b.totalVoterCount)
+					b.isMostVoted = false
+				}
+			}
+		}
+	}
+	if !found {
+		return errors.New("no previous voted block")
+	}
+	// add new vote
+	b.voters = append(b.voters, voter)
+	if 2*len(b.voters) > b.totalVoterCount {
+		log.Infof("got enough votes for block %s after changing mind (%d votes / %d neighbors)",
+			BytesToHexString(hash.ToArrayReverse()), len(b.voters), b.totalVoterCount)
+		b.isMostVoted = true
+	}
 
 	return nil
 }

--- a/net/node/neighbor.go
+++ b/net/node/neighbor.go
@@ -136,10 +136,23 @@ func (node *node) GetNeighborNoder() []Noder {
 	nodes := []Noder{}
 	for _, n := range node.nbrNodes.List {
 		if n.GetState() == ESTABLISH {
-			node := n
-			nodes = append(nodes, node)
+			nodes = append(nodes, n)
 		}
 	}
+	return nodes
+}
+
+func (node *node) GetSyncFinishedNeighbors() []Noder {
+	node.nbrNodes.RLock()
+	defer node.nbrNodes.RUnlock()
+
+	var nodes []Noder
+	for _, n := range node.nbrNodes.List {
+		if n.GetState() == ESTABLISH && n.GetSyncState() == PersistFinished {
+			nodes = append(nodes, n)
+		}
+	}
+
 	return nodes
 }
 

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -604,7 +604,7 @@ func (node *node) SendPingToNbr() {
 	noders := node.local.GetNeighborNoder()
 	for _, n := range noders {
 		if n.GetState() == ESTABLISH {
-			buf, err := NewPingMsg()
+			buf, err := NewPingMsg(node.syncState)
 			if err != nil {
 				log.Error("failed build a new ping message")
 			} else {

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -93,6 +93,7 @@ type Noder interface {
 	CleanSubmittedTransactions(txns []*transaction.Transaction) error
 
 	GetNeighborNoder() []Noder
+	GetSyncFinishedNeighbors() []Noder
 	GetNbrNodeCnt() uint32
 	StoreFlightHeight(height uint32)
 	GetFlightHeightCnt() int


### PR DESCRIPTION
1. Detecting neighbor sync state by using ping and pong messages.
Neighbor node which in syncing mode will be ignored while local node
syncing block.

2. Listen to neighbor's proposal and mind changing messages when
sync block to determine if cached block which proposed by
block proposer is acceptable. The stop hash of block sycing will be
decided by the first cached block.