### PR TITLE
 Voting for cached blocks when sync block

### DIFF
--- a/consensus/ising/proposerservice.go
+++ b/consensus/ising/proposerservice.go
@@ -370,7 +370,7 @@ func (ps *ProposerService) ChangeProposer() {
 }
 
 func (ps *ProposerService) BlockSyncingFinished(v interface{}) {
-	for i := ps.syncCache.minHeight; i < ps.syncCache.maxHeight; i++ {
+	for i := ps.syncCache.startHeight; i < ps.syncCache.nextHeight; i++ {
 		block, err := ps.syncCache.GetBlockFromSyncCache(i)
 		if err != nil {
 			//TODO: if found ambiguous block then re-sync block

--- a/consensus/ising/timelock.go
+++ b/consensus/ising/timelock.go
@@ -1,0 +1,51 @@
+package ising
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+type TimeLock struct {
+	sync.RWMutex
+	locker map[uint32]*time.Timer
+}
+
+func NewTimeLock() *TimeLock {
+	return &TimeLock{
+		locker: make(map[uint32]*time.Timer),
+	}
+}
+
+func (tl *TimeLock) LockForHeight(height uint32, timer *time.Timer) {
+	tl.Lock()
+	defer tl.Unlock()
+
+	if _, ok := tl.locker[height]; !ok {
+		tl.locker[height] = timer
+	}
+}
+
+func (tl *TimeLock) RemoveForHeight(height uint32) {
+	tl.Lock()
+	defer tl.Unlock()
+
+	delete(tl.locker, height)
+}
+
+func (tl *TimeLock) WaitForTimeout(height uint32) error {
+	tl.RLock()
+	defer tl.RUnlock()
+
+	timer, ok := tl.locker[height]
+	if !ok {
+		return fmt.Errorf("no time locker for height: %d", height)
+	}
+	// wait for time locker expired
+	select {
+	case <-timer.C:
+		// reset right away after timer expired
+		timer.Reset(0)
+	}
+	return nil
+}

--- a/net/node/neighbor.go
+++ b/net/node/neighbor.go
@@ -136,10 +136,23 @@ func (node *node) GetNeighborNoder() []Noder {
 	nodes := []Noder{}
 	for _, n := range node.nbrNodes.List {
 		if n.GetState() == ESTABLISH {
-			node := n
-			nodes = append(nodes, node)
+			nodes = append(nodes, n)
 		}
 	}
+	return nodes
+}
+
+func (node *node) GetSyncFinishedNeighbors() []Noder {
+	node.nbrNodes.RLock()
+	defer node.nbrNodes.RUnlock()
+
+	var nodes []Noder
+	for _, n := range node.nbrNodes.List {
+		if n.GetState() == ESTABLISH && n.GetSyncState() == PersistFinished {
+			nodes = append(nodes, n)
+		}
+	}
+
 	return nodes
 }
 

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -49,6 +49,7 @@ func (s Semaphore) acquire() { s <- struct{}{} }
 func (s Semaphore) release() { <-s }
 
 type node struct {
+	sync.Mutex
 	state                    uint32              // node connection state
 	id                       uint64              // node ID
 	cap                      [32]byte            // node capability
@@ -795,6 +796,8 @@ func (node *node) SetSyncState(s SyncState) {
 }
 
 func (node *node) SetSyncStopHash(hash Uint256, height uint32) {
+	node.Lock()
+	defer node.Unlock()
 	if node.syncStopHash == EmptyUint256 {
 		log.Infof("block syncing will stop when receive block: %s, height: %d",
 			BytesToHexString(hash.ToArrayReverse()), height)

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -93,6 +93,7 @@ type Noder interface {
 	CleanSubmittedTransactions(txns []*transaction.Transaction) error
 
 	GetNeighborNoder() []Noder
+	GetSyncFinishedNeighbors() []Noder
 	GetNbrNodeCnt() uint32
 	StoreFlightHeight(height uint32)
 	GetFlightHeightCnt() int


### PR DESCRIPTION
Detecting neighbor sync state by using ping and pong messages.
Neighbor node which in syncing mode will be ignored while local node
syncing block.

Listen to neighbor's proposal and mind changing messages when
sync block to determine if cached block which proposed by
block proposer is acceptable. The stop hash of block sycing will be
decided by the first cached block.