### PR TITLE
unify timestamp to int64

### DIFF
--- a/consensus/dbft/consensusContext.go
+++ b/consensus/dbft/consensusContext.go
@@ -27,7 +27,7 @@ type ConsensusContext struct {
 	Owner           *crypto.PubKey
 	BookKeeperIndex int
 	PrimaryIndex    uint32
-	Timestamp       uint32
+	Timestamp       int64
 	Nonce           uint64
 	NextBookKeeper  Uint160
 	Transactions    []*tx.Transaction

--- a/consensus/dbft/dbftService.go
+++ b/consensus/dbft/dbftService.go
@@ -361,7 +361,7 @@ func (ds *DbftService) PrepareRequestReceived(payload *msg.ConsensusPayload, mes
 
 	//TODO Add Error Catch
 	prevBlockTimestamp := header.Timestamp
-	if payload.Timestamp <= prevBlockTimestamp || payload.Timestamp > uint32(time.Now().Add(time.Minute*10).Unix()) {
+	if payload.Timestamp <= prevBlockTimestamp || payload.Timestamp > time.Now().Add(time.Minute*10).Unix() {
 		log.Info(fmt.Sprintf("Prepare Reques tReceived: Timestamp incorrect: %d", payload.Timestamp))
 		return
 	}
@@ -519,7 +519,7 @@ func (ds *DbftService) Timeout() {
 		log.Info("Send prepare request: height: ", ds.timerHeight, " View: ", ds.timeView, " State: ", ds.context.GetStateDetail())
 		ds.context.State |= RequestSent
 		if !ds.context.State.HasFlag(SignatureSent) {
-			now := uint32(time.Now().Unix())
+			now := time.Now().Unix()
 			header, _ := ledger.DefaultLedger.Blockchain.GetHeader(ds.context.PrevHash)
 
 			//set context Timestamp

--- a/consensus/ising/proposerservice.go
+++ b/consensus/ising/proposerservice.go
@@ -326,8 +326,8 @@ func (ps *ProposerService) BlockPersistCompleted(v interface{}) {
 		ps.proposerChangeIndex = 0
 		// reset timer when block persisted
 		ps.proposerChangeTimer.Stop()
-		duration := time.Duration(block.Header.Timestamp) + ProposerChangeTime - time.Duration(time.Now().Unix())
-		ps.proposerChangeTimer.Reset(duration)
+		t := block.Header.Timestamp + int64(ProposerChangeTime) - time.Now().Unix()
+		ps.proposerChangeTimer.Reset(time.Duration(t))
 	}
 }
 
@@ -512,7 +512,7 @@ func (ps *ProposerService) BuildBlock() (*ledger.Block, error) {
 	header := &ledger.Header{
 		Version:          0,
 		PrevBlockHash:    ledger.DefaultLedger.Store.GetCurrentBlockHash(),
-		Timestamp:        uint32(time.Now().Unix()),
+		Timestamp:        time.Now().Unix(),
 		Height:           ledger.DefaultLedger.Store.GetHeight() + 1,
 		ConsensusData:    rand.Uint64(),
 		TransactionsRoot: txnRoot,

--- a/core/ledger/block.go
+++ b/core/ledger/block.go
@@ -167,7 +167,7 @@ func GenesisBlockInit() (*Block, error) {
 		Version:          BlockVersion,
 		PrevBlockHash:    Uint256{},
 		TransactionsRoot: Uint256{},
-		Timestamp:        uint32(uint32(time.Date(2018, time.January, 0, 0, 0, 0, 0, time.UTC).Unix())),
+		Timestamp:        time.Date(2018, time.January, 0, 0, 0, 0, 0, time.UTC).Unix(),
 		Height:           uint32(0),
 		ConsensusData:    GenesisNonce,
 		NextBookKeeper:   Uint160{},

--- a/core/ledger/header.go
+++ b/core/ledger/header.go
@@ -18,7 +18,7 @@ type Header struct {
 	Version          uint32
 	PrevBlockHash    Uint256
 	TransactionsRoot Uint256
-	Timestamp        uint32
+	Timestamp        int64
 	Height           uint32
 	ConsensusData    uint64
 	NextBookKeeper   Uint160
@@ -43,7 +43,7 @@ func (h *Header) SerializeUnsigned(w io.Writer) error {
 	serialization.WriteUint32(w, h.Version)
 	h.PrevBlockHash.Serialize(w)
 	h.TransactionsRoot.Serialize(w)
-	serialization.WriteUint32(w, h.Timestamp)
+	serialization.WriteUint64(w, uint64(h.Timestamp))
 	serialization.WriteUint32(w, h.Height)
 	serialization.WriteUint64(w, h.ConsensusData)
 	h.NextBookKeeper.Serialize(w)
@@ -99,8 +99,8 @@ func (h *Header) DeserializeUnsigned(r io.Reader) error {
 	h.TransactionsRoot = *txRoot
 
 	//Timestamp
-	temp, _ = serialization.ReadUint32(r)
-	h.Timestamp = temp
+	time, _ := serialization.ReadUint64(r)
+	h.Timestamp = int64(time)
 
 	//Height
 	temp, _ = serialization.ReadUint32(r)

--- a/core/ledger/jsontype.go
+++ b/core/ledger/jsontype.go
@@ -9,7 +9,7 @@ type HeaderInfo struct {
 	Version          uint32              `json:"version"`
 	PrevBlockHash    string              `json:"prevBlockHash"`
 	TransactionsRoot string              `json:"transactionsRoot"`
-	Timestamp        uint32              `json:"timestamp"`
+	Timestamp        int64               `json:"timestamp"`
 	Height           uint32              `json:"height"`
 	ConsensusData    uint64              `json:"consensusData"`
 	NextBookKeeper   string              `json:"nextBookKeeper"`

--- a/net/message/consensus.go
+++ b/net/message/consensus.go
@@ -25,7 +25,7 @@ type ConsensusPayload struct {
 	PrevHash        common.Uint256
 	Height          uint32
 	BookKeeperIndex uint16
-	Timestamp       uint32
+	Timestamp       int64
 	Data            []byte
 	Owner           *crypto.PubKey
 	Program         *program.Program
@@ -98,7 +98,7 @@ func (cp *ConsensusPayload) SerializeUnsigned(w io.Writer) error {
 	cp.PrevHash.Serialize(w)
 	serialization.WriteUint32(w, cp.Height)
 	serialization.WriteUint16(w, cp.BookKeeperIndex)
-	serialization.WriteUint32(w, cp.Timestamp)
+	serialization.WriteUint64(w, uint64(cp.Timestamp))
 	serialization.WriteVarBytes(w, cp.Data)
 	err := cp.Owner.Serialize(w)
 	if err != nil {
@@ -163,11 +163,12 @@ func (cp *ConsensusPayload) DeserializeUnsigned(r io.Reader) error {
 		return errors.New("consensus item BookKeeperIndex Deserialize failed.")
 	}
 
-	cp.Timestamp, err = serialization.ReadUint32(r)
+	time, err := serialization.ReadUint64(r)
 	if err != nil {
 		log.Warn("consensus item Timestamp Deserialize failed.")
 		return errors.New("consensus item Timestamp Deserialize failed.")
 	}
+	cp.Timestamp = int64(time)
 
 	cp.Data, err = serialization.ReadVarBytes(r)
 	if err != nil {

--- a/net/message/version.go
+++ b/net/message/version.go
@@ -25,7 +25,7 @@ type version struct {
 	P   struct {
 		Version      uint32
 		Services     uint64
-		TimeStamp    uint32
+		TimeStamp    int64
 		Port         uint16
 		HttpInfoPort uint16
 		Cap          [32]byte
@@ -55,7 +55,7 @@ func NewVersion(n Noder) ([]byte, error) {
 	}
 
 	// FIXME Time overflow
-	msg.P.TimeStamp = uint32(time.Now().UTC().UnixNano())
+	msg.P.TimeStamp = time.Now().UTC().UnixNano()
 	msg.P.Port = n.GetPort()
 	msg.P.Nonce = n.GetID()
 	msg.P.UserAgent = 0x00


### PR DESCRIPTION
Both uint32 and int64 for timestamp exist in code, unify it to int64.

Signed-off-by: oscar <oscar@nkn.org>