### PR TITLE
changes for block proposer verification

### DIFF
--- a/consensus/ising/mining.go
+++ b/consensus/ising/mining.go
@@ -16,7 +16,7 @@ import (
 )
 
 type Mining interface {
-	BuildBlock() (*ledger.Block, error)
+	BuildBlock(height uint32, winningHash Uint256, winningHashType ledger.WinningHashType) (*ledger.Block, error)
 }
 
 type BuiltinMining struct {
@@ -32,7 +32,8 @@ func NewBuiltinMining(account *vault.Account, txnCollector *transaction.TxnColle
 	}
 }
 
-func (bm *BuiltinMining) BuildBlock() (*ledger.Block, error) {
+func (bm *BuiltinMining) BuildBlock(height uint32, winningHash Uint256,
+	winningHashType ledger.WinningHashType) (*ledger.Block, error) {
 	var txnList []*transaction.Transaction
 	var txnHashList []Uint256
 	coinbase := bm.CreateCoinbaseTransaction()
@@ -57,10 +58,12 @@ func (bm *BuiltinMining) BuildBlock() (*ledger.Block, error) {
 		Version:          0,
 		PrevBlockHash:    ledger.DefaultLedger.Store.GetCurrentBlockHash(),
 		Timestamp:        time.Now().Unix(),
-		Height:           ledger.DefaultLedger.Store.GetHeight() + 1,
+		Height:           height,
 		ConsensusData:    rand.Uint64(),
 		TransactionsRoot: txnRoot,
 		NextBookKeeper:   Uint160{},
+		WinningHash:      winningHash,
+		WinningHashType:  winningHashType,
 		Signer:           encodedPubKey,
 		Signature:        nil,
 		Program: &program.Program{

--- a/consensus/ising/mining.go
+++ b/consensus/ising/mining.go
@@ -1,0 +1,107 @@
+package ising
+
+import (
+	"math/rand"
+	"time"
+
+	. "github.com/nknorg/nkn/common"
+	"github.com/nknorg/nkn/core/contract/program"
+	"github.com/nknorg/nkn/core/ledger"
+	"github.com/nknorg/nkn/core/signature"
+	"github.com/nknorg/nkn/core/transaction"
+	"github.com/nknorg/nkn/core/transaction/payload"
+	"github.com/nknorg/nkn/crypto"
+	"github.com/nknorg/nkn/crypto/util"
+	"github.com/nknorg/nkn/vault"
+)
+
+type Mining interface {
+	BuildBlock() (*ledger.Block, error)
+}
+
+type BuiltinMining struct {
+	account      *vault.Account            // local account
+	txnCollector *transaction.TxnCollector // transaction pool
+}
+
+func NewBuiltinMining(account *vault.Account, txnCollector *transaction.TxnCollector) *BuiltinMining {
+
+	return &BuiltinMining{
+		account:      account,
+		txnCollector: txnCollector,
+	}
+}
+
+func (bm *BuiltinMining) BuildBlock() (*ledger.Block, error) {
+	var txnList []*transaction.Transaction
+	var txnHashList []Uint256
+	coinbase := bm.CreateCoinbaseTransaction()
+	txnList = append(txnList, coinbase)
+	txnHashList = append(txnHashList, coinbase.Hash())
+	txns := bm.txnCollector.Collect()
+	for txnHash, txn := range txns {
+		if !ledger.DefaultLedger.Store.IsTxHashDuplicate(txnHash) {
+			txnList = append(txnList, txn)
+			txnHashList = append(txnHashList, txnHash)
+		}
+	}
+	txnRoot, err := crypto.ComputeRoot(txnHashList)
+	if err != nil {
+		return nil, err
+	}
+	encodedPubKey, err := bm.account.PublicKey.EncodePoint(true)
+	if err != nil {
+		return nil, err
+	}
+	header := &ledger.Header{
+		Version:          0,
+		PrevBlockHash:    ledger.DefaultLedger.Store.GetCurrentBlockHash(),
+		Timestamp:        time.Now().Unix(),
+		Height:           ledger.DefaultLedger.Store.GetHeight() + 1,
+		ConsensusData:    rand.Uint64(),
+		TransactionsRoot: txnRoot,
+		NextBookKeeper:   Uint160{},
+		Signer:           encodedPubKey,
+		Signature:        nil,
+		Program: &program.Program{
+			Code:      []byte{0x00},
+			Parameter: []byte{0x00},
+		},
+	}
+	hash := signature.GetHashForSigning(header)
+	sig, err := crypto.Sign(bm.account.PrivateKey, hash)
+	if err != nil {
+		return nil, err
+	}
+	header.Signature = append(header.Signature, sig...)
+
+	block := &ledger.Block{
+		Header:       header,
+		Transactions: txnList,
+	}
+
+	return block, nil
+}
+
+func (bm *BuiltinMining) CreateCoinbaseTransaction() *transaction.Transaction {
+	return &transaction.Transaction{
+		TxType:         transaction.Coinbase,
+		PayloadVersion: 0,
+		Payload:        &payload.Coinbase{},
+		Attributes: []*transaction.TxnAttribute{
+			{
+				Usage: transaction.Nonce,
+				Data:  util.RandomBytes(transaction.TransactionNonceLength),
+			},
+		},
+		Inputs: []*transaction.TxnInput{},
+		Outputs: []*transaction.TxnOutput{
+			{
+				AssetID:     ledger.DefaultLedger.Blockchain.AssetID,
+				Value:       10 * StorageFactor,
+				ProgramHash: bm.account.ProgramHash,
+			},
+		},
+		Programs: []*program.Program{},
+	}
+}

--- a/consensus/ising/proposercache.go
+++ b/consensus/ising/proposercache.go
@@ -1,0 +1,107 @@
+package ising
+
+import (
+	"fmt"
+	"sync"
+	"errors"
+
+	. "github.com/nknorg/nkn/common"
+	"github.com/nknorg/nkn/consensus/ising/voting"
+	"github.com/nknorg/nkn/core/ledger"
+	"github.com/nknorg/nkn/core/transaction"
+	"github.com/nknorg/nkn/crypto"
+	"github.com/nknorg/nkn/util/config"
+	"github.com/nknorg/nkn/util/log"
+	"github.com/nknorg/nkn/core/transaction/payload"
+	"github.com/nknorg/nkn/por"
+	"github.com/golang/protobuf/proto"
+)
+
+const (
+	InitialBlockHeight = 5
+)
+
+type ProposerInfo struct {
+	publicKey       []byte
+	winningHash     Uint256
+	winningHashType ledger.WinningHashType
+}
+
+type ProposerCache struct {
+	sync.RWMutex
+	cache map[uint32]*ProposerInfo
+}
+
+func NewProposerCache() *ProposerCache {
+	return &ProposerCache{
+		cache: make(map[uint32]*ProposerInfo),
+	}
+}
+
+func (pc *ProposerCache) Add(height uint32, votingContent voting.VotingContent) {
+	pc.Lock()
+	defer pc.Unlock()
+
+	var proposerInfo *ProposerInfo
+	switch t := votingContent.(type) {
+	case *ledger.Block:
+		signer, _ := t.GetSigner()
+		proposerInfo = &ProposerInfo{
+			publicKey:       signer,
+			winningHash:     t.Hash(),
+			winningHashType: ledger.WinningBlockHash,
+		}
+		log.Warnf("use proposer of block height %d which public key is %s to propose block %d",
+			t.Header.Height, BytesToHexString(signer), height)
+	case *transaction.Transaction:
+		payload := t.Payload.(*payload.Commit)
+		sigchain := &por.SigChain{}
+		proto.Unmarshal(payload.SigChain, sigchain)
+		// TODO: get a determinate public key on signature chain
+		pbk, err := sigchain.GetLedgerNodePubkey()
+		if err != nil {
+			log.Warn("Get last public key error", err)
+			return
+		}
+		proposerInfo = &ProposerInfo{
+			publicKey: pbk,
+			winningHash:t.Hash(),
+			winningHashType:ledger.WinningTxnHash,
+		}
+		sigChainTxnHash:=t.Hash()
+		log.Infof("sigchain transaction consensus: %s, %s will be block proposer for height %d",
+			BytesToHexString(sigChainTxnHash.ToArrayReverse()), BytesToHexString(pbk), height)
+	}
+
+	pc.cache[height] = proposerInfo
+}
+
+func (pc *ProposerCache) Get(height uint32) (*ProposerInfo, error) {
+	pc.RLock()
+	defer pc.RUnlock()
+	// initial blocks are produced byte GenesisBlockProposer
+	if height < InitialBlockHeight {
+		if len(config.Parameters.GenesisBlockProposer) < 1 {
+			err := errors.New("no GenesisBlockProposer configured")
+			log.Warn(err)
+			return nil, err
+		}
+		proposer, err := HexStringToBytes(config.Parameters.GenesisBlockProposer[0])
+		if err != nil || len(proposer) != crypto.COMPRESSEDLEN {
+			err := errors.New("invalid GenesisBlockProposer configured")
+			return nil, err
+		}
+
+		return &ProposerInfo{
+			publicKey:       proposer,
+			winningHash:     EmptyUint256,
+			winningHashType: ledger.GenesisHash,
+		}, nil
+	}
+
+	if _, ok := pc.cache[height]; !ok {
+		return nil, fmt.Errorf("no proposer info for height: ", height)
+	}
+
+	return pc.cache[height], nil
+}

--- a/consensus/ising/proposerservice.go
+++ b/consensus/ising/proposerservice.go
@@ -203,8 +203,13 @@ func (ps *ProposerService) ProduceNewBlock() {
 	current := ps.CurrentVoting(voting.BlockVote)
 	votingPool := current.GetVotingPool()
 	votingHeight := current.GetVotingHeight()
+	proposerInfo, err := ps.proposerCache.Get(votingHeight)
+	if err != nil {
+		log.Error("get proposer info for producing new block error: ", err)
+		return
+	}
 	// build new block to be proposed
-	block, err := ps.mining.BuildBlock()
+	block, err := ps.mining.BuildBlock(votingHeight, proposerInfo.winningHash, proposerInfo.winningHashType)
 	if err != nil {
 		log.Error("building block error: ", err)
 	}

--- a/consensus/ising/voting/block.go
+++ b/consensus/ising/voting/block.go
@@ -9,6 +9,11 @@ import (
 	"github.com/nknorg/nkn/util/log"
 )
 
+const (
+	// When current block height is n, the block for height n+VotedBlockHeightIncrement is being voted.
+	VotedBlockHeightIncrement = 1
+)
+
 type BlockVoting struct {
 	sync.RWMutex
 	pstate         map[Uint256]*State            // consensus state for proposer
@@ -93,7 +98,7 @@ func (bv *BlockVoting) SetVotingHeight(height uint32) {
 }
 
 func (bv *BlockVoting) GetVotingHeight() uint32 {
-	return ledger.DefaultLedger.Store.GetHeight() + 1
+	return ledger.DefaultLedger.Store.GetHeight() + VotedBlockHeightIncrement
 }
 
 func (bv *BlockVoting) SetConfirmingHash(hash Uint256) {

--- a/consensus/ising/voting/sigchain.go
+++ b/consensus/ising/voting/sigchain.go
@@ -10,6 +10,11 @@ import (
 	"github.com/nknorg/nkn/por"
 )
 
+const (
+	// When current block height is n, the signature chain for height n+VotedSigChainHeightIncrement is being voted.
+	VotedSigChainHeightIncrement = 3
+)
+
 type SigChainVoting struct {
 	sync.RWMutex
 	pstate         map[Uint256]*State            // consensus state for proposer
@@ -95,7 +100,7 @@ func (scv *SigChainVoting) SetVotingHeight(height uint32) {
 }
 
 func (scv *SigChainVoting) GetVotingHeight() uint32 {
-	return ledger.DefaultLedger.Store.GetHeight() + 3
+	return ledger.DefaultLedger.Store.GetHeight() + VotedSigChainHeightIncrement
 }
 
 func (scv *SigChainVoting) SetConfirmingHash(hash Uint256) {

--- a/consensus/ising/voting/sigchain.go
+++ b/consensus/ising/voting/sigchain.go
@@ -95,7 +95,7 @@ func (scv *SigChainVoting) SetVotingHeight(height uint32) {
 }
 
 func (scv *SigChainVoting) GetVotingHeight() uint32 {
-	return ledger.DefaultLedger.Store.GetHeight() + 2
+	return ledger.DefaultLedger.Store.GetHeight() + 3
 }
 
 func (scv *SigChainVoting) SetConfirmingHash(hash Uint256) {

--- a/core/ledger/header.go
+++ b/core/ledger/header.go
@@ -14,6 +14,14 @@ import (
 	. "github.com/nknorg/nkn/errors"
 )
 
+type WinningHashType byte
+
+const (
+	GenesisHash      WinningHashType = 0
+	WinningTxnHash   WinningHashType = 1
+	WinningBlockHash WinningHashType = 2
+)
+
 type Header struct {
 	Version          uint32
 	PrevBlockHash    Uint256

--- a/core/ledger/jsontype.go
+++ b/core/ledger/jsontype.go
@@ -14,6 +14,7 @@ type HeaderInfo struct {
 	ConsensusData    uint64              `json:"consensusData"`
 	NextBookKeeper   string              `json:"nextBookKeeper"`
 	Signer           string              `json:"signer"`
+	Signature        string              `json:"signature"`
 	Program          program.ProgramInfo `json:"program"`
 
 	Hash string `json:"hash"`

--- a/core/ledger/jsontype.go
+++ b/core/ledger/jsontype.go
@@ -13,6 +13,8 @@ type HeaderInfo struct {
 	Height           uint32              `json:"height"`
 	ConsensusData    uint64              `json:"consensusData"`
 	NextBookKeeper   string              `json:"nextBookKeeper"`
+	WinningHash      string              `json:"winningHash"`
+	WinningHashType  byte                `json:"winningHashType"`
 	Signer           string              `json:"signer"`
 	Signature        string              `json:"signature"`
 	Program          program.ProgramInfo `json:"program"`

--- a/por/porpackage.go
+++ b/por/porpackage.go
@@ -13,14 +13,14 @@ import (
 )
 
 const (
-	// The height of signature chain which run for block proposer should be (local block height -1 + 4)
+	// The height of signature chain which run for block proposer should be (local block height -1 + 5)
 	// -1 means that:
 	//  local block height may heigher than neighbor node at most 1
-	// +4 means that:
-	//  2 (if local block height is n, then n + 2 signature chain is in consensus) +
+	// +5 means that:
+	// if local block height is n, then n + 3 signature chain is in consensus) +
 	//  1 (since local node height may lower than neighbors at most 1) +
 	//  1 (for fully propagate)
-	HeightThreshold = 4
+	HeightThreshold = 5
 )
 
 type PorPackages []*PorPackage

--- a/por/porserver.go
+++ b/por/porserver.go
@@ -159,6 +159,24 @@ func (ps *PorServer) GetSigChain(height uint32, hash common.Uint256) (*SigChain,
 	return nil, errors.New("can't find the signature chain")
 }
 
+func (ps *PorServer) GetTxnHashBySigChainHeight(height uint32) ([]common.Uint256, error) {
+	ps.RLock()
+	defer ps.RUnlock()
+
+	var txnHashes []common.Uint256
+	if porPackages, ok := ps.pors[height]; ok {
+		for _, p := range porPackages {
+			hash, err := common.Uint256ParseFromBytes(p.TxHash)
+			if err != nil {
+				return nil, errors.New("invalid transaction hash for por package")
+			}
+			txnHashes = append(txnHashes, hash)
+		}
+	}
+
+	return txnHashes, nil
+}
+
 func (ps *PorServer) AddSigChainFromTx(txn *transaction.Transaction) error {
 	porpkg, err := NewPorPackage(txn)
 	if err != nil {


### PR DESCRIPTION
1. Exclusive signature chain transactions from block when sigchain height
is current height + 3. Making sure the sigchain transaction could be packaged in previous block.

2. Modularize block mining and add block signing.

3. cache block proposer info in ProposerCache, cache more things such as winning info(hash and hash type).

4. add winning info(hash and hash type) to block header for verifying next block.

Signed-off-by: oscar <oscar@nkn.org>