### PR TITLE
Refactoring of Makefile to support multiple os architectures.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,4 @@ vendor
 Chain
 nknd
 nknc
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ nknd
 nknc
 cscope*
 *~
+build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ADD . /go/src/github.com/nknorg/nkn
 WORKDIR /go/src/github.com/nknorg/nkn
 RUN make glide
 RUN make vendor
-RUN make all
+RUN make build_local
 RUN cp nknd nknc /usr/local/go/bin/
 
 WORKDIR /nkn

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,52 @@
+.DEFAULT_GOAL := help
+
 GOFMT=gofmt
 GC=go build
 VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
 Minversion := $(shell date)
-BUILD_NKND_PARAM = -ldflags "-X github.com/nknorg/nkn/util/config.Version=$(VERSION)" #-race
-BUILD_NKNC_PARAM = -ldflags "-X github.com/nknorg/nkn/cli/common.Version=$(VERSION)"
+BUILD_NKND_PARAM = -ldflags "-s -w -X github.com/nknorg/nkn/util/config.Version=$(VERSION)" #-race
+BUILD_NKNC_PARAM = -ldflags "-s -w -X github.com/nknorg/nkn/cli/common.Version=$(VERSION)"
+IDENTIFIER= $(GOOS)-$(GOARCH)
+
+help:          ## Show available options with this Makefile
+	@grep -F -h "##" $(MAKEFILE_LIST) | grep -v grep | awk 'BEGIN { FS = ":.*?##" }; { printf "%-15s  %s\n", $$1,$$2 }'
 
 .PHONY: nknd
-nknd: vendor
+nknd: vendor ## Build nknd binary only
 	$(GC)  $(BUILD_NKND_PARAM) nknd.go
 
+.PHONY: build
+build:
+	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GC)  $(BUILD_NKND_PARAM) -o $(FLAGS)/nknd nknd.go
+	GOOS=$(GOOS) GOARCH=$(GOARCH) $(GC)  $(BUILD_NKNC_PARAM) -o $(FLAGS)/nknc nknc.go
+
+.PHONY: crossbuild
+crossbuild:
+	mkdir -p build/$(IDENTIFIER)
+	make build FLAGS="build/$(IDENTIFIER)"
+
 .PHONY: all
-all: vendor
+all: vendor ## Build binaries for all available architectures
+	make crossbuild GOOS=linux GOARCH=arm
+	make crossbuild GOOS=linux GOARCH=386
+	make crossbuild GOOS=linux GOARCH=arm64
+	make crossbuild GOOS=linux GOARCH=amd64
+	make crossbuild GOOS=darwin GOARCH=amd64
+	make crossbuild GOOS=darwin GOARCH=386
+	make crossbuild GOOS=windows GOARCH=amd64
+	make crossbuild GOOS=windows GOARCH=386
+
+.PHONY: build_local
+build_local: vendor ## Build local binaries without providing specific GOOS/GOARCH
 	$(GC)  $(BUILD_NKND_PARAM) nknd.go
 	$(GC)  $(BUILD_NKNC_PARAM) nknc.go
 
 .PHONY: format
-format:
+format:   ## Run go format on nknd.go
 	$(GOFMT) -w nknd.go
 
 .PHONY: glide
-glide:
+glide:   ## Installs glide for go package management
 	@ mkdir -p $$GOPATH/bin
 	@ curl https://glide.sh/get | sh;
 
@@ -27,7 +54,7 @@ vendor: glide.yaml glide.lock
 	@ glide install
 
 .PHONY: test
-test:
+test:  ## Run go test
 	go test -v github.com/nknorg/nkn/common
 	go test -v github.com/nknorg/nkn/net
 	go test -v github.com/nknorg/nkn/por
@@ -35,9 +62,10 @@ test:
 	go test -v github.com/nknorg/nkn/cli
 
 .PHONY: clean
-clean:
+clean:  ## Remove the nknd, nknc binaries and build directory
 	rm -rf nknd nknc
+	rm -rf build/
 
 .PHONY: deepclean
-deepclean:
-	rm -rf nknd nknc vendor
+deepclean:  ## Remove the existing binaries, the vendor directory and build directory
+	rm -rf nknd nknc vendor build

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ make vendor
 Build the source code with make
 
 ```shell
-$ make all
+$ make build_local
 ```
 
 After building is successful, you should see two executables:
@@ -97,6 +97,7 @@ After building is successful, you should see two executables:
 * `nknd`: the nkn node program
 * `nknc`: command line tool for nkn node control
 
+NOTE: To build binaries for other architectures execute `make all`. The resulting binaries are stored in `build` directory.
 
 ### Building using docker
 
@@ -136,7 +137,7 @@ Start other nodes by joining the network
 $ docker run -p 30000-30003:30000-30003 -v $PWD:/nkn -it nkn nknd
 ```
 
-*NOTE:* The `-it` argument mean `Run interactively` and `Create a pseudo-tty`. Basically it means, 
+*NOTE:* The `-it` argument mean `Run interactively` and `Create a pseudo-tty`. Basically it means,
 that it really wants to take the input from you. For using in scripts and running in the background
 (for example a startup job) you should omit the `-it` argument
 
@@ -233,4 +234,3 @@ git commit -s
 * [Telegram](https://t.me/nknorg)
 * [Reddit](https://www.reddit.com/r/nknblockchain/)
 * [Twitter](https://twitter.com/NKN_ORG)
-


### PR DESCRIPTION
### Proposed changes in this pull request
1. This is a refactoring of Makefile mostly to enable users to build binaries for multiple architectures.
2. `make` command if executed without a target, produces `help` documentation.
``` $  make
help              Show available options with this Makefile
nknd              Build nknd binary only
all               Build binaries for all available architectures
build_local       Build local binaries without providing specific GOOS/GOARCH
format            Run go format on nknd.go
glide             Installs glide for go package management
test              Run go test
clean             Remove the nknd, nknc binaries and build directory
deepclean         Remove the existing binaries, the vendor directory and build directory
```
3. `make all` will build for multiple GOOS/GOARCH combinations ( check `make all` for details )
4. `make all` now results in a `build` directory which looks like this:
```
 $  tree  build/
build/
├── darwin-386
│   ├── nknc
│   └── nknd
├── darwin-amd64
│   ├── nknc
│   └── nknd
├── linux-386
│   ├── nknc
│   └── nknd
├── linux-amd64
│   ├── nknc
│   └── nknd
├── linux-arm
│   ├── nknc
│   └── nknd
├── linux-arm64
│   ├── nknc
│   └── nknd
├── windows-386
│   ├── nknc
│   └── nknd
└── windows-amd64
    ├── nknc
    └── nknd
```
### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [x] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written. (`N/A`)
- [x] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide]  (`N/A`)(https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)


