### PR TITLE
[Improved] Hex Vnode.Id of getchordringinfo API for readability

### DIFF
--- a/net/chord/chord.go
+++ b/net/chord/chord.go
@@ -94,6 +94,13 @@ type Vnode struct {
 	HttpWsPort uint16 // Websocket port
 }
 
+type VnodeData struct {
+	Id         string // Virtual ID of Hex String
+	Host       string // Chord Host identifier
+	NodePort   uint16 // Node port
+	HttpWsPort uint16 // Websocket port
+}
+
 // Represents a local Vnode
 type localVnode struct {
 	Vnode
@@ -109,10 +116,10 @@ type localVnode struct {
 
 // localVnodeData : Data of localVnode for json.Marshal in API
 type localVnodeData struct {
-	Vnode
-	Successors  []*Vnode
-	Finger      []*Vnode
-	Predecessor *Vnode
+	VnodeData
+	Successors  []*VnodeData
+	Finger      []*VnodeData
+	Predecessor *VnodeData
 	Last_finger int
 }
 

--- a/net/chord/ring.go
+++ b/net/chord/ring.go
@@ -198,33 +198,17 @@ func (r *Ring) shouldConnectToHost(host string) bool {
 	return false
 }
 
-func reduceSameNode(lst []*Vnode) (ret []*Vnode) {
-	ret = make([]*Vnode, len(lst))
-
-	if lst == nil || len(lst) <= 0 {
-		return ret
-	}
-
-	last := lst[0]
-	for i, n := range lst {
-		if n != last { // Skip same item, Only save the last when new item
-			ret[i-1] = last // n != last is impossible when i==0
-			last = n        // Update last
-		}
-	}
-	ret[len(lst)-1] = last // save last at end of lst
-
-	return ret
-}
-
 // ToData: Extract marshalable data from Ring struct
 func (r *Ring) ToData() *RingData {
+	if r == nil {
+		return nil
+	}
+
 	c := r.config.toData()
 	nodes := make([]*localVnodeData, len(r.Vnodes))
 
 	for i, n := range r.Vnodes {
 		nodes[i] = n.toData()
-		nodes[i].Finger = reduceSameNode(n.finger)
 	}
 
 	return &RingData{Conf: c, Vnodes: nodes}


### PR DESCRIPTION
Signed-off-by: gdmmx <gdmmx@163.com>

### Proposed changes in this pull request
Hex Vnode.Id of getchordringinfo API for readability

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
N/A
- [ ] Added proper documentation where ever applicable (in code and README.md).
N/A
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information