### PR TITLE
Fix bug that cause wrong network topology

### DIFF
--- a/net/chord/ring.go
+++ b/net/chord/ring.go
@@ -1,7 +1,6 @@
 package chord
 
 import (
-	"bytes"
 	"errors"
 	"sort"
 
@@ -72,7 +71,7 @@ func (r *Ring) Len() int {
 // Less returns whether the vnode with index i should sort
 // before the vnode with index j.
 func (r *Ring) Less(i, j int) bool {
-	return bytes.Compare(r.Vnodes[i].Id, r.Vnodes[j].Id) == -1
+	return CompareId(r.Vnodes[i].Id, r.Vnodes[j].Id) == -1
 }
 
 // Swap swaps the vnodes with indexes i and j.
@@ -83,7 +82,7 @@ func (r *Ring) Swap(i, j int) {
 // Returns the nearest local vnode to the key
 func (r *Ring) nearestVnode(key []byte) *localVnode {
 	for i := len(r.Vnodes) - 1; i >= 0; i-- {
-		if bytes.Compare(r.Vnodes[i].Id, key) == -1 {
+		if CompareId(r.Vnodes[i].Id, key) == -1 {
 			return r.Vnodes[i]
 		}
 	}

--- a/net/chord/ring_test.go
+++ b/net/chord/ring_test.go
@@ -1,7 +1,6 @@
 package chord
 
 import (
-	"bytes"
 	"crypto/sha1"
 	"encoding/json"
 	"sort"
@@ -78,16 +77,16 @@ func TestRingLen(t *testing.T) {
 func TestRingSort(t *testing.T) {
 	ring := makeRing()
 	sort.Sort(ring)
-	if bytes.Compare(ring.Vnodes[0].Id, ring.Vnodes[1].Id) != -1 {
+	if CompareId(ring.Vnodes[0].Id, ring.Vnodes[1].Id) != -1 {
 		t.Fatalf("bad sort")
 	}
-	if bytes.Compare(ring.Vnodes[1].Id, ring.Vnodes[2].Id) != -1 {
+	if CompareId(ring.Vnodes[1].Id, ring.Vnodes[2].Id) != -1 {
 		t.Fatalf("bad sort")
 	}
-	if bytes.Compare(ring.Vnodes[2].Id, ring.Vnodes[3].Id) != -1 {
+	if CompareId(ring.Vnodes[2].Id, ring.Vnodes[3].Id) != -1 {
 		t.Fatalf("bad sort")
 	}
-	if bytes.Compare(ring.Vnodes[3].Id, ring.Vnodes[4].Id) != -1 {
+	if CompareId(ring.Vnodes[3].Id, ring.Vnodes[4].Id) != -1 {
 		t.Fatalf("bad sort")
 	}
 }

--- a/net/chord/transport_test.go
+++ b/net/chord/transport_test.go
@@ -1,7 +1,6 @@
 package chord
 
 import (
-	"bytes"
 	"testing"
 )
 
@@ -170,7 +169,7 @@ func TestLocalFindSucc(t *testing.T) {
 	if res[0] != suc[0] {
 		t.Fatalf("got wrong successor")
 	}
-	if bytes.Compare(mockVN.key, key) != 0 {
+	if CompareId(mockVN.key, key) != 0 {
 		t.Fatalf("didn't get key correctly!")
 	}
 

--- a/net/chord/util.go
+++ b/net/chord/util.go
@@ -8,6 +8,17 @@ import (
 	"time"
 )
 
+func CompareId(id1, id2 []byte) int {
+	l1, l2 := len(id1), len(id2)
+	if l1 < l2 {
+		return -1
+	}
+	if l1 > l2 {
+		return 1
+	}
+	return bytes.Compare(id1, id2)
+}
+
 // Generates a random stabilization time
 func randStabilize(conf *Config) time.Duration {
 	min := conf.StabilizeMin
@@ -19,26 +30,26 @@ func randStabilize(conf *Config) time.Duration {
 // Checks if a key is STRICTLY between two ID's exclusively
 func between(id1, id2, key []byte) bool {
 	// Check for ring wrap around
-	if bytes.Compare(id1, id2) == 1 {
-		return bytes.Compare(id1, key) == -1 ||
-			bytes.Compare(id2, key) == 1
+	if CompareId(id1, id2) == 1 {
+		return CompareId(id1, key) == -1 ||
+			CompareId(id2, key) == 1
 	}
 
 	// Handle the normal case
-	return bytes.Compare(id1, key) == -1 &&
-		bytes.Compare(id2, key) == 1
+	return CompareId(id1, key) == -1 &&
+		CompareId(id2, key) == 1
 }
 
 // Checks if a key is between two ID's, right inclusive
 func betweenRightIncl(id1, id2, key []byte) bool {
 	// Check for ring wrap around
-	if bytes.Compare(id1, id2) == 1 {
-		return bytes.Compare(id1, key) == -1 ||
-			bytes.Compare(id2, key) >= 0
+	if CompareId(id1, id2) == 1 {
+		return CompareId(id1, key) == -1 ||
+			CompareId(id2, key) >= 0
 	}
 
-	return bytes.Compare(id1, key) == -1 &&
-		bytes.Compare(id2, key) >= 0
+	return CompareId(id1, key) == -1 &&
+		CompareId(id2, key) >= 0
 }
 
 // Computes the offset by (n + 2^exp) % (2^mod)
@@ -92,7 +103,7 @@ func min(a, b int) int {
 // Returns the vnode nearest a key
 func nearestVnodeToKey(vnodes []*Vnode, key []byte) *Vnode {
 	for i := len(vnodes) - 1; i >= 0; i-- {
-		if bytes.Compare(vnodes[i].Id, key) == -1 {
+		if CompareId(vnodes[i].Id, key) == -1 {
 			return vnodes[i]
 		}
 	}

--- a/net/chord/vnode.go
+++ b/net/chord/vnode.go
@@ -1,7 +1,6 @@
 package chord
 
 import (
-	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -210,7 +209,7 @@ func (vn *localVnode) Notify(maybe_pred *Vnode) ([]*Vnode, error) {
 	// Check if we should update our predecessor
 	if vn.predecessor == nil || between(vn.predecessor.Id, vn.Id, maybe_pred.Id) {
 		shouldUpdate = true
-	} else if bytes.Compare(vn.predecessor.Id, maybe_pred.Id) != 0 {
+	} else if CompareId(vn.predecessor.Id, maybe_pred.Id) != 0 {
 		alive, err := vn.ring.transport.Ping(vn.predecessor)
 		if err == nil && !alive {
 			shouldUpdate = true
@@ -485,7 +484,7 @@ func (vn *localVnode) ShouldAddrInNeighbors(addr []byte) bool {
 		if n.Host == vn.Host {
 			continue
 		}
-		if bytes.Compare(n.Id, addr) == 0 {
+		if CompareId(n.Id, addr) == 0 {
 			return true
 		}
 	}

--- a/net/chord/vnode_test.go
+++ b/net/chord/vnode_test.go
@@ -1,7 +1,6 @@
 package chord
 
 import (
-	"bytes"
 	"crypto/sha256"
 	"sort"
 	"testing"
@@ -59,7 +58,7 @@ func TestGenId(t *testing.T) {
 
 	for idx, val := range ids {
 		for i := 0; i < len(ids); i++ {
-			if idx != i && bytes.Compare(ids[i], val) == 0 {
+			if idx != i && CompareId(ids[i], val) == 0 {
 				t.Fatalf("unexpected id collision!")
 			}
 		}

--- a/net/message/verack.go
+++ b/net/message/verack.go
@@ -66,6 +66,5 @@ func (msg verACK) Handle(node Noder) error {
 	// but it doesn't matter to access the invalid
 	// node which will trigger a warning
 	node.ReqNeighborList()
-	node.LocalNode().RemoveAddrInConnectingList(node.GetAddrStr())
 	return nil
 }

--- a/net/node/link.go
+++ b/net/node/link.go
@@ -226,7 +226,7 @@ func (node *node) Connect(nodeAddr string) error {
 		return nil
 	}
 	if !node.SetAddrInConnectingList(nodeAddr) {
-		log.Error("node", nodeAddr, "exists in connecting list, cancel")
+		log.Info("Node addr", nodeAddr, "exists in connecting list, cancel")
 		return errors.New("node exists in connecting list, cancel")
 	}
 

--- a/net/node/link.go
+++ b/net/node/link.go
@@ -226,7 +226,8 @@ func (node *node) Connect(nodeAddr string) error {
 		return nil
 	}
 	if !node.SetAddrInConnectingList(nodeAddr) {
-		return errors.New("node exist in connecting list, cancel")
+		log.Error("node", nodeAddr, "exists in connecting list, cancel")
+		return errors.New("node exists in connecting list, cancel")
 	}
 
 	isTls := Parameters.IsTLS

--- a/net/node/neighbor.go
+++ b/net/node/neighbor.go
@@ -131,6 +131,19 @@ func (node *node) GetNeighborHeights() ([]uint32, uint64) {
 	return heights, i
 }
 
+func (node *node) GetActiveNeighbors() []Noder {
+	node.nbrNodes.RLock()
+	defer node.nbrNodes.RUnlock()
+
+	nodes := []Noder{}
+	for _, n := range node.nbrNodes.List {
+		if n.GetState() != INACTIVITY {
+			nodes = append(nodes, n)
+		}
+	}
+	return nodes
+}
+
 func (node *node) GetNeighborNoder() []Noder {
 	node.nbrNodes.RLock()
 	defer node.nbrNodes.RUnlock()

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -659,7 +659,6 @@ func (node *node) ConnectNeighbors() {
 		if !node.IsChordAddrInNeighbors(chordNbr.Id) {
 			chordNbrAddr, err := chordNbr.NodeAddr()
 			if err != nil {
-				log.Error("Get chord neighbor node addr error:", err)
 				continue
 			}
 			log.Infof("Trying to connect to chord node %x at %s", chordNbr.Id, chordNbrAddr)

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -167,4 +167,7 @@ func (config *Configuration) IncrementPort() {
 	config.NodePort += delta
 	config.HttpWsPort += delta
 	config.HttpJsonPort += delta
+	if delta > 0 {
+		log.Println("[WARNING] Port in use! All ports are automatically increased by", delta)
+	}
 }


### PR DESCRIPTION
1. If connection is closed when a remote node is in connecting list, the remote node should be removed from connecting list, otherwise the remote node will never be connected again.
2. When comparing chord id, shorter length id should always be less than longer id (effectively add zero padding in front of chord id that is shorter than hashbit).

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
