### PR TITLE
Fix chord CompareId not correct if one id starts with zero

### DIFF
--- a/net/chord/util.go
+++ b/net/chord/util.go
@@ -3,6 +3,7 @@ package chord
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"math/big"
 	"math/rand"
 	"time"
@@ -10,13 +11,28 @@ import (
 
 func CompareId(id1, id2 []byte) int {
 	l1, l2 := len(id1), len(id2)
-	if l1 < l2 {
-		return -1
-	}
 	if l1 > l2 {
-		return 1
+		return -CompareId(id2, id1)
+	}
+	if l1 < l2 {
+		tmp := make([]byte, l2)
+		copy(tmp[l2-l1:], id1)
+		id1 = tmp
 	}
 	return bytes.Compare(id1, id2)
+}
+
+func bigIntToId(i big.Int, m int) []byte {
+	b := i.Bytes()
+	lb := len(b)
+	lId := m / 8
+	if lb >= lId {
+		log.Println("[WARNING] Big integer has more bytes than ID.")
+		return b
+	}
+	id := make([]byte, lId)
+	copy(id[lId-lb:], b)
+	return id
 }
 
 // Generates a random stabilization time
@@ -78,8 +94,7 @@ func powerOffset(id []byte, exp int, mod int) []byte {
 	// Apply the mod
 	idInt.Mod(&sum, &ceil)
 
-	// Add together
-	return idInt.Bytes()
+	return bigIntToId(idInt, mod)
 }
 
 // max returns the max of two ints


### PR DESCRIPTION
Fix chord CompareId not correct if one id starts with zero

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)
