### PR TITLE
Add ConnectingTimeout to prune connectinglist

### DIFF
--- a/net/chord/util.go
+++ b/net/chord/util.go
@@ -26,13 +26,15 @@ func bigIntToId(i big.Int, m int) []byte {
 	b := i.Bytes()
 	lb := len(b)
 	lId := m / 8
-	if lb >= lId {
-		log.Println("[WARNING] Big integer has more bytes than ID.")
-		return b
+	if lb < lId {
+		id := make([]byte, lId)
+		copy(id[lId-lb:], b)
+		return id
 	}
-	id := make([]byte, lId)
-	copy(id[lId-lb:], b)
-	return id
+	if lb > lId {
+		log.Println("[WARNING] Big integer has more bytes than ID.")
+	}
+	return b
 }
 
 // Generates a random stabilization time

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -36,6 +36,7 @@ const (
 	ProtocolVersion      = 0                // protocol version
 	ConnectionTicker     = 10 * time.Second // ticker for connection
 	MaxReqBlkOnce        = 16               // max block count requested
+	ConnectingTimeout    = 10 * time.Second // timeout for waiting for connection
 )
 
 type Semaphore chan struct{}
@@ -112,6 +113,10 @@ func (node *node) SetAddrInConnectingList(addr string) (added bool) {
 		}
 	}
 	node.ConnectingAddrs = append(node.ConnectingAddrs, addr)
+	go func() {
+		time.Sleep(ConnectingTimeout)
+		node.RemoveAddrInConnectingList(addr)
+	}()
 	return true
 }
 


### PR DESCRIPTION
KeepaliveTimeout only check, close, and remove connection from
connecting list to neighbors. If a node get disconnected before
added to neighbor list, then it will never be removed from the
connecting list, blocking future reconnection.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)
