### PR TITLE
limit goroutine number for handling message

### DIFF
--- a/net/message/blockHdr.go
+++ b/net/message/blockHdr.go
@@ -147,8 +147,8 @@ func (msg *blkHeader) Deserialize(r io.Reader) error {
 }
 
 func (msg headersReq) Handle(node Noder) error {
-	node.LocalNode().AcqSyncReqSem()
-	defer node.LocalNode().RelSyncReqSem()
+	node.LocalNode().AcquireHeaderReqChan()
+	defer node.LocalNode().ReleaseHeaderReqChan()
 	var startHash [HashLen]byte
 	var stopHash [HashLen]byte
 	startHash = msg.p.hashStart

--- a/net/message/message.go
+++ b/net/message/message.go
@@ -211,6 +211,8 @@ func NewMsg(t string, n Noder) ([]byte, error) {
 
 // FIXME the length exceed int32 case?
 func HandleNodeMsg(node Noder, buf []byte, len int) error {
+	defer node.LocalNode().ReleaseMsgHandlerChan()
+
 	if len < MsgHdrLen {
 		log.Warn("Unexpected size of received message")
 		return errors.New("Unexpected size of received message")

--- a/net/node/chanqueue.go
+++ b/net/node/chanqueue.go
@@ -1,0 +1,10 @@
+package node
+
+type ChanQueue chan struct{}
+
+func MakeChanQueue(n int) ChanQueue {
+	return make(chan struct{}, n)
+}
+
+func (s ChanQueue) acquire() { s <- struct{}{} }
+func (s ChanQueue) release() { <-s }

--- a/net/node/link.go
+++ b/net/node/link.go
@@ -75,6 +75,7 @@ func unpackNodeBuf(node *node, buf []byte) {
 	msgLen = node.rxBuf.len
 	if len(buf) == msgLen {
 		msgBuf = append(node.rxBuf.p, buf[:]...)
+		node.LocalNode().AcquireMsgHandlerChan()
 		go msg.HandleNodeMsg(node, msgBuf, len(msgBuf))
 		node.rxBuf.p = nil
 		node.rxBuf.len = 0
@@ -83,6 +84,7 @@ func unpackNodeBuf(node *node, buf []byte) {
 		node.rxBuf.len = msgLen - len(buf)
 	} else {
 		msgBuf = append(node.rxBuf.p, buf[0:msgLen]...)
+		node.LocalNode().AcquireMsgHandlerChan()
 		go msg.HandleNodeMsg(node, msgBuf, len(msgBuf))
 		node.rxBuf.p = nil
 		node.rxBuf.len = 0

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -115,8 +115,10 @@ type Noder interface {
 	RemoveAddrInConnectingList(addr string)
 	AddInRetryList(addr string)
 	RemoveFromRetryList(addr string)
-	AcqSyncReqSem()
-	RelSyncReqSem()
+	AcquireMsgHandlerChan()
+	ReleaseMsgHandlerChan()
+	AcquireHeaderReqChan()
+	ReleaseHeaderReqChan()
 
 	GetChordAddr() []byte
 	SetChordAddr([]byte)


### PR DESCRIPTION
### Proposed changes in this pull request
goroutine will be created to handle message when message comes. If lots of message reached together, lots of goroutines will be created. It too heavy for system. Limiting the goroutine number in this patch. 

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Enhancement
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
