### PR TITLE
Fix nil pointer error in FindSuccessors

### DIFF
--- a/net/chord/net.go
+++ b/net/chord/net.go
@@ -119,14 +119,17 @@ func InitTCPTransport(listen string, timeout time.Duration) (*TCPTransport, erro
 
 // Checks for a local vnode
 func (t *TCPTransport) get(vn *Vnode) (VnodeRPC, bool) {
+	if vn == nil {
+		return nil, false
+	}
 	key := vn.String()
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 	w, ok := t.local[key]
-	if ok {
+	if ok && w != nil && w.obj != nil {
 		return w.obj, ok
 	} else {
-		return nil, ok
+		return nil, false
 	}
 }
 
@@ -768,7 +771,7 @@ func (t *TCPTransport) handleConn(conn *net.TCPConn) {
 			obj, ok := t.get(body.Target)
 			resp := tcpBodyVnodeListError{}
 			sendResp = &resp
-			if ok {
+			if ok && obj != nil {
 				nodes, err := obj.FindSuccessors(body.Num, body.Key)
 				resp.Vnodes = trimSlice(nodes)
 				resp.Err = err

--- a/net/chord/transport.go
+++ b/net/chord/transport.go
@@ -34,14 +34,17 @@ func InitLocalTransport(remote Transport) Transport {
 
 // Checks for a local vnode
 func (lt *LocalTransport) get(vn *Vnode) (VnodeRPC, bool) {
+	if vn == nil {
+		return nil, false
+	}
 	key := vn.String()
 	lt.lock.RLock()
 	defer lt.lock.RUnlock()
 	w, ok := lt.local[key]
-	if ok {
+	if ok && w != nil && w.obj != nil {
 		return w.obj, ok
 	} else {
-		return nil, ok
+		return nil, false
 	}
 }
 

--- a/net/chord/vnode.go
+++ b/net/chord/vnode.go
@@ -315,7 +315,7 @@ func (vn *localVnode) checkPredecessor() error {
 // Finds next N successors. N must be <= NumSuccessors
 func (vn *localVnode) FindSuccessors(n int, key []byte) ([]*Vnode, error) {
 	// Check if we are the immediate predecessor
-	if betweenRightIncl(vn.Id, vn.successors[0].Id, key) {
+	if len(vn.successors) > 0 && vn.successors[0] != nil && betweenRightIncl(vn.Id, vn.successors[0].Id, key) {
 		return vn.successors[:n], nil
 	}
 
@@ -343,7 +343,7 @@ func (vn *localVnode) FindSuccessors(n int, key []byte) ([]*Vnode, error) {
 
 	// Check if the ID is between us and any non-immediate successors
 	for i := 1; i <= successors-n; i++ {
-		if betweenRightIncl(vn.Id, vn.successors[i].Id, key) {
+		if vn.successors[i] != nil && betweenRightIncl(vn.Id, vn.successors[i].Id, key) {
 			remain := vn.successors[i:]
 			if len(remain) > n {
 				remain = remain[:n]


### PR DESCRIPTION
Fix nil pointer error in FindSuccessors

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.