### PR TITLE
Broadcast transactions to all neighbors rather than persistfinished

### DIFF
--- a/net/node/node.go
+++ b/net/node/node.go
@@ -387,7 +387,7 @@ func (node *node) BroadcastTransaction(from Noder, txn *transaction.Transaction)
 		return err
 	}
 	node.txnCnt++
-	for _, n := range node.GetSyncFinishedNeighbors() {
+	for _, n := range node.GetNeighborNoder() {
 		if n.GetRelay() && n.GetID() != from.GetID() {
 			n.Tx(buffer)
 		}


### PR DESCRIPTION
Broadcast transactions to all neighbors rather than persistfinished ones to prevent tx not spread bug.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.