### PR TITLE
Fix Chord inbound connections concurrent map iteration and map write error

### DIFF
--- a/net/chord/net.go
+++ b/net/chord/net.go
@@ -623,15 +623,15 @@ func (t *TCPTransport) reapOnce() {
 		t.pool[host] = conns[:max]
 	}
 
+	t.lock.Lock()
 	for conn, lastUsed := range t.inbound {
 		if time.Since(lastUsed) > t.maxIdle {
 			log.Printf("[INFO] Close timeout inbound connection with %s.", conn.RemoteAddr().String())
-			t.lock.Lock()
 			delete(t.inbound, conn)
-			t.lock.Unlock()
 			conn.Close()
 		}
 	}
+	t.lock.Unlock()
 }
 
 // Listens for inbound connections


### PR DESCRIPTION
Fix Chord inbound connections concurrent map iteration and map write error

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.