### PR TITLE
Use chord id instead of pubkey for node id

### DIFF
--- a/net/node/node.go
+++ b/net/node/node.go
@@ -171,11 +171,13 @@ func InitNode(pubKey *crypto.PubKey, ring *chord.Ring) Noder {
 	n.link.httpJSONPort = Parameters.HttpJsonPort
 	n.relay = true
 
-	key, err := pubKey.EncodePoint(true)
+	chordVnode, err := ring.GetFirstVnode()
 	if err != nil {
 		log.Error(err)
 	}
-	err = binary.Read(bytes.NewBuffer(key[:8]), binary.LittleEndian, &(n.id))
+	n.chordAddr = chordVnode.Id
+
+	err = binary.Read(bytes.NewBuffer(n.chordAddr[:8]), binary.LittleEndian, &(n.id))
 	if err != nil {
 		log.Error(err)
 	}
@@ -192,12 +194,6 @@ func InitNode(pubKey *crypto.PubKey, ring *chord.Ring) Noder {
 	n.hashCache = NewHashCache(HashCacheCap)
 	n.nodeDisconnectSubscriber = n.eventQueue.GetEvent("disconnect").Subscribe(events.EventNodeDisconnect, n.NodeDisconnected)
 	n.ring = ring
-
-	chordVnode, err := ring.GetFirstVnode()
-	if err != nil {
-		log.Error(err)
-	}
-	n.chordAddr = chordVnode.Id
 
 	go n.initConnection()
 	go n.updateConnection()


### PR DESCRIPTION
Use chord id instead of pubkey for node id
This should fix bug caused by multiple nodes share wallet

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
