### PR TITLE
send vote in sync mode if node has ability to verify block

### DIFF
--- a/consensus/ising/synccache.go
+++ b/consensus/ising/synccache.go
@@ -90,7 +90,7 @@ func (sc *SyncCache) GetBlockFromSyncCache(height uint32) (*ledger.VBlock, error
 
 // AddBlockToSyncCache caches received block and the voter count when receive block.
 // Returns nil if block already existed.
-func (sc *SyncCache) AddBlockToSyncCache(block *ledger.Block) error {
+func (sc *SyncCache) AddBlockToSyncCache(block *ledger.Block, rtime int64) error {
 	sc.Lock()
 	defer sc.Unlock()
 
@@ -115,7 +115,7 @@ func (sc *SyncCache) AddBlockToSyncCache(block *ledger.Block) error {
 
 	blockInfo := &BlockInfo{
 		block:       block,
-		receiveTime: time.Now().Unix(),
+		receiveTime: rtime,
 	}
 	// analyse cached votes when add new block
 	if voteInfo, ok := sc.voteCache[blockHeight]; ok {

--- a/consensus/ising/util.go
+++ b/consensus/ising/util.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 
 	. "github.com/nknorg/nkn/common"
+	"github.com/nknorg/nkn/core/ledger"
 )
 
 // HeightHashToString uses block height and block hash to generate a uniq string
@@ -25,4 +26,24 @@ func StringToHeightHash(str string) (uint32, Uint256) {
 	hash.Deserialize(buff)
 
 	return height, hash
+}
+
+// HasAbilityToVerifyBlock checks if local node can verify the block.
+func HasAbilityToVerifyBlock(block *ledger.Block) bool {
+	// get current block
+	currentBlockHeight := ledger.DefaultLedger.Store.GetHeight()
+	currentBlock, err := ledger.DefaultLedger.Store.GetBlockByHeight(currentBlockHeight)
+	if err != nil {
+		return false
+	}
+	// check if can link to previous block
+	if block.Header.PrevBlockHash.CompareTo(currentBlock.Header.Hash()) != 0 {
+		return false
+	}
+	// check block height
+	if block.Header.Height != currentBlockHeight+1 {
+		return false
+	}
+
+	return true
 }

--- a/consensus/ising/voting/block.go
+++ b/consensus/ising/voting/block.go
@@ -3,7 +3,6 @@ package voting
 import (
 	"errors"
 	"sync"
-	"time"
 
 	. "github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/core/ledger"
@@ -170,7 +169,7 @@ func (bv *BlockVoting) VotingType() VotingContentType {
 	return BlockVote
 }
 
-func (bv *BlockVoting) AddToCache(content VotingContent) error {
+func (bv *BlockVoting) AddToCache(content VotingContent, rtime int64) error {
 	var err error
 	if block, ok := content.(*ledger.Block); !ok {
 		return errors.New("invalid voting content type")
@@ -180,7 +179,7 @@ func (bv *BlockVoting) AddToCache(content VotingContent) error {
 		if blockHeight != localHeight+1 {
 			return errors.New("invalid block height")
 		}
-		err = ledger.HeaderCheck(block.Header, time.Now().Unix())
+		err = ledger.HeaderCheck(block.Header, rtime)
 		if err != nil {
 			return err
 		}

--- a/consensus/ising/voting/sigchain.go
+++ b/consensus/ising/voting/sigchain.go
@@ -172,7 +172,7 @@ func (scv *SigChainVoting) VotingType() VotingContentType {
 	return SigChainTxnVote
 }
 
-func (scv *SigChainVoting) AddToCache(content VotingContent) error {
+func (scv *SigChainVoting) AddToCache(content VotingContent, rtime int64) error {
 	errCode := scv.txnCollector.Append(content.(*transaction.Transaction))
 	if errCode != 0 {
 		return errors.New("append transaction error")

--- a/consensus/ising/voting/voting.go
+++ b/consensus/ising/voting/voting.go
@@ -17,7 +17,7 @@ type VotingContent interface {
 
 type Voting interface {
 	// add voting entity to cache
-	AddToCache(content VotingContent) error
+	AddToCache(content VotingContent, rtime int64) error
 	// get voting content type
 	VotingType() VotingContentType
 	// set hash in process


### PR DESCRIPTION
### Proposed changes in this pull request
All nodes get into block syncing mode first when networking restarts. If can't sent vote to neighbors in syncing mode,  some nodes may only receive block but no votes. This will cause block will not be persisted.
So in this patch, change the logic to:
When in block syncing mode, if a node receives a block which could be verified locally then verify and send vote to neighbors.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
