### PR TITLE
proposer node no need to process cached blocks when start

### DIFF
--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -60,7 +60,7 @@ type Noder interface {
 	SetSyncStopHash(hash Uint256, height uint32)
 	SyncBlock(bool)
 	SyncBlockMonitor(bool)
-	StopSyncBlock()
+	StopSyncBlock(bool)
 	GetRelay() bool
 	GetPubKey() *crypto.PubKey
 	CompareAndSetState(old, new uint32) bool


### PR DESCRIPTION
### Proposed changes in this pull request
When node restart if local node is the block proposer, get into PersistedFinished state right away and skip processing block sync cache.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
