### PR TITLE
Remove fixed length read to prevent crash if src is empty

### DIFF
--- a/consensus/ising/proposercache.go
+++ b/consensus/ising/proposercache.go
@@ -64,7 +64,7 @@ func (pc *ProposerCache) Add(height uint32, votingContent voting.VotingContent) 
 			return
 		}
 		var id uint64
-		err = binary.Read(bytes.NewBuffer(chordID[:8]), binary.LittleEndian, &id)
+		err = binary.Read(bytes.NewBuffer(chordID), binary.LittleEndian, &id)
 		if err != nil {
 			log.Error(err)
 		}

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -177,7 +177,7 @@ func InitNode(pubKey *crypto.PubKey, ring *chord.Ring) Noder {
 	}
 	n.chordAddr = chordVnode.Id
 
-	err = binary.Read(bytes.NewBuffer(n.chordAddr[:8]), binary.LittleEndian, &(n.id))
+	err = binary.Read(bytes.NewBuffer(n.chordAddr), binary.LittleEndian, &(n.id))
 	if err != nil {
 		log.Error(err)
 	}


### PR DESCRIPTION
Remove fixed length read to prevent crash if src is empty

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.