### PR TITLE
Fixed RPCServer throwing errors on CORS preflight

### DIFF
--- a/api/httpjson/RPCserver.go
+++ b/api/httpjson/RPCserver.go
@@ -60,91 +60,69 @@ func (s *RPCServer) Handle(w http.ResponseWriter, r *http.Request) {
 	s.mainMux.RLock()
 	defer s.mainMux.RUnlock()
 	//CORS headers
-	w.Header().Add("Access-Control-Allow-Headers", "Content-Type")
+	w.Header().Add("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
 	w.Header().Set("content-type", "application/json;charset=utf-8")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	//JSON RPC commands should be POSTs
-	if r.Method != "POST" {
-		if s.mainMux.defaultFunction != nil {
-			log.Info("HTTP JSON RPC Handle - Method!=\"POST\"")
-			s.mainMux.defaultFunction(w, r)
-			return
-		} else {
-			log.Warn("HTTP JSON RPC Handle - Method!=\"POST\"")
+	if r.Method == "POST" {
+		//read the body of the request
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Error("HTTP JSON RPC Handle - ioutil.ReadAll: ", err)
 			return
 		}
-	}
-
-	//check if there is Request Body to read
-	if r.Body == nil {
-		if s.mainMux.defaultFunction != nil {
-			log.Info("HTTP JSON RPC Handle - Request body is nil")
-			s.mainMux.defaultFunction(w, r)
-			return
-		} else {
-			log.Warn("HTTP JSON RPC Handle - Request body is nil")
+		request := make(map[string]interface{})
+		err = json.Unmarshal(body, &request)
+		if err != nil {
+			log.Error("HTTP JSON RPC Handle - json.Unmarshal: ", err)
 			return
 		}
-	}
 
-	//read the body of the request
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		log.Error("HTTP JSON RPC Handle - ioutil.ReadAll: ", err)
-		return
-	}
-	request := make(map[string]interface{})
-	err = json.Unmarshal(body, &request)
-	if err != nil {
-		log.Error("HTTP JSON RPC Handle - json.Unmarshal: ", err)
-		return
-	}
-
-	//get the corresponding function
-	function, ok := s.mainMux.m[request["method"].(string)]
-	if ok {
-		var data []byte
-		var err error
-		response := function(s, request["params"].(map[string]interface{}))
-		errcode := response["error"].(common.ErrCode)
-		if errcode != common.SUCCESS {
-			data, err = json.Marshal(map[string]interface{}{
+		//get the corresponding function
+		function, ok := s.mainMux.m[request["method"].(string)]
+		if ok {
+			var data []byte
+			var err error
+			response := function(s, request["params"].(map[string]interface{}))
+			errcode := response["error"].(common.ErrCode)
+			if errcode != common.SUCCESS {
+				data, err = json.Marshal(map[string]interface{}{
+					"jsonrpc": "2.0",
+					"error": map[string]interface{}{
+						"code":    -errcode,
+						"message": common.ErrMessage[errcode],
+					},
+					"id": request["id"],
+				})
+			} else {
+				data, err = json.Marshal(map[string]interface{}{
+					"jsonrpc": "2.0",
+					"result":  response["result"],
+					"id":      request["id"],
+				})
+			}
+			if err != nil {
+				log.Error("HTTP JSON RPC Handle - json.Marshal: ", err)
+				return
+			}
+			w.Write(data)
+		} else {
+			//if the function does not exist
+			log.Warn("HTTP JSON RPC Handle - No function to call for ", request["method"])
+			data, err := json.Marshal(map[string]interface{}{
 				"jsonrpc": "2.0",
 				"error": map[string]interface{}{
-					"code":    -errcode,
-					"message": common.ErrMessage[errcode],
+					"code":    -32601,
+					"message": "Method not found",
+					"data":    "The called method was not found on the server",
 				},
 				"id": request["id"],
 			})
-		} else {
-			data, err = json.Marshal(map[string]interface{}{
-				"jsonrpc": "2.0",
-				"result":  response["result"],
-				"id":      request["id"],
-			})
+			if err != nil {
+				log.Error("HTTP JSON RPC Handle - json.Marshal: ", err)
+				return
+			}
+			w.Write(data)
 		}
-		if err != nil {
-			log.Error("HTTP JSON RPC Handle - json.Marshal: ", err)
-			return
-		}
-		w.Write(data)
-	} else {
-		//if the function does not exist
-		log.Warn("HTTP JSON RPC Handle - No function to call for ", request["method"])
-		data, err := json.Marshal(map[string]interface{}{
-			"jsonrpc": "2.0",
-			"error": map[string]interface{}{
-				"code":    -32601,
-				"message": "Method not found",
-				"data":    "The called method was not found on the server",
-			},
-			"id": request["id"],
-		})
-		if err != nil {
-			log.Error("HTTP JSON RPC Handle - json.Marshal: ", err)
-			return
-		}
-		w.Write(data)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Christian Busch <kontakt@christian-busch.com>

### Proposed changes in this pull request
Some Servers sent a CORS preflight to see if the endpoint can actually understand the CORS-protocol. This is a OPTIONS request that causes the RPCServer to run into an error (https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request). 
Made RPCServer.go only to listen for POST-requests and allowed needed header-requests.

### Type (put an `x` where ever applicable)
- [x] Bug fix
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
none
