### PR TITLE
At least 3 votes is required when set block sync target

### DIFF
--- a/consensus/ising/voting/blockvotingpool.go
+++ b/consensus/ising/voting/blockvotingpool.go
@@ -86,7 +86,7 @@ func (bvp *BlockVotingPool) AddVoteThenCounting(height uint32, nodeID uint64, we
 	bvp.addToReceivePool(height, nodeID, weight, hash)
 
 	// return when voter is not enough
-	if len(bvp.receivePool[height]) < MinVoterNum {
+	if len(bvp.receivePool[height]) < MinConsensusVotesNum {
 		return nil, errors.New("voter is not enough")
 	}
 

--- a/consensus/ising/voting/sigchainvotingpool.go
+++ b/consensus/ising/voting/sigchainvotingpool.go
@@ -86,7 +86,7 @@ func (scvp *SigChainVotingPool) AddVoteThenCounting(height uint32, nodeID uint64
 	scvp.addToReceivePool(height, nodeID, weight, hash)
 
 	// return when voter is not enough
-	if len(scvp.receivePool[height]) < MinVoterNum {
+	if len(scvp.receivePool[height]) < MinConsensusVotesNum {
 		return nil, errors.New("voter is not enough")
 	}
 

--- a/consensus/ising/voting/votingpool.go
+++ b/consensus/ising/voting/votingpool.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	MinVoterNum = 3
+	MinConsensusVotesNum = 3
 )
 
 type VoteInfo struct {


### PR DESCRIPTION
### Proposed changes in this pull request
At least 3 votes is required when set block sync target

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Enhancement
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
