### PR TITLE
modify HandleMindChangingMsg mechanism

### DIFF
--- a/consensus/ising/proposerservice.go
+++ b/consensus/ising/proposerservice.go
@@ -875,20 +875,22 @@ func (ps *ProposerService) HandleMindChangingMsg(mindChanging *MindChanging, sen
 
 	// handle mind changing when block syncing
 	if ps.localNode.GetSyncState() != protocol.PersistFinished {
-		ps.syncCache.AddVoteForBlock(hash, height, sender)
+		if mindChanging.contentType == voting.BlockVote {
+			ps.syncCache.AddVoteForBlock(hash, height, sender)
+		}
 		return
 	}
 
 	current := ps.CurrentVoting(mindChanging.contentType)
 	votingType := current.VotingType()
 	votingHeight := current.GetVotingHeight()
-	if height < votingHeight {
+	if height != votingHeight {
 		log.Warnf("receive invalid mind changing, consensus height: %d, mind changing height: %d,"+
 			" hash: %s", votingHeight, height, BytesToHexString(hash.ToArrayReverse()))
 		return
 	}
 	currentVotingPool := current.GetVotingPool()
-	if currentVotingPool.HasReceivedVoteFrom(votingHeight, sender) {
+	if !currentVotingPool.HasReceivedVoteFrom(votingHeight, sender) {
 		log.Warn("no proposal received before, so mind changing is invalid")
 		return
 	}


### PR DESCRIPTION
1. add vote for block only whein contenttype is BlockVote.
2. return when MindChangingMsg is higher than current voting.

Signed-off-by: NoelBright <noel.n.bright@gmail.com>

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
