### PR TITLE
validate tx with other txs inside pool/block

### DIFF
--- a/core/ledger/validator.go
+++ b/core/ledger/validator.go
@@ -41,6 +41,9 @@ func TransactionCheck(block *Block) error {
 		if errCode := tx.VerifyTransaction(txn); errCode != ErrNoError {
 			return errors.New("transaction sanity check failed")
 		}
+		if errCode := tx.VerifyTransactionWithBlock(block.Transactions); errCode != ErrNoError {
+			return errors.New("transaction block check failed")
+		}
 		if errCode := tx.VerifyTransactionWithLedger(txn); errCode != ErrNoError {
 			return errors.New("transaction history check failed")
 		}

--- a/core/ledger/validator.go
+++ b/core/ledger/validator.go
@@ -29,15 +29,15 @@ type VBlock struct {
 
 type TransactionArray []*tx.Transaction
 
-func (iterable TransactionArray) Iterate(handler func(item *tx.Transaction) interface{}) interface{} {
+func (iterable TransactionArray) Iterate(handler func(item *tx.Transaction) ErrCode) ErrCode {
 	for _, item := range iterable {
 		result := handler(item)
-		if result != nil {
+		if result != ErrNoError {
 			return result
 		}
 	}
 
-	return nil
+	return ErrNoError
 }
 
 func TransactionCheck(block *Block) error {

--- a/core/ledger/validator.go
+++ b/core/ledger/validator.go
@@ -27,6 +27,19 @@ type VBlock struct {
 	ReceiveTime int64
 }
 
+type TransactionArray []*tx.Transaction
+
+func (iterable TransactionArray) Iterate(handler func(item *tx.Transaction) interface{}) interface{} {
+	for _, item := range iterable {
+		result := handler(item)
+		if result != nil {
+			return result
+		}
+	}
+
+	return nil
+}
+
 func TransactionCheck(block *Block) error {
 	if block.Transactions == nil {
 		return errors.New("empty block")
@@ -41,7 +54,7 @@ func TransactionCheck(block *Block) error {
 		if errCode := tx.VerifyTransaction(txn); errCode != ErrNoError {
 			return errors.New("transaction sanity check failed")
 		}
-		if errCode := tx.VerifyTransactionWithBlock(block.Transactions); errCode != ErrNoError {
+		if errCode := tx.VerifyTransactionWithBlock(TransactionArray(block.Transactions)); errCode != ErrNoError {
 			return errors.New("transaction block check failed")
 		}
 		if errCode := tx.VerifyTransactionWithLedger(txn); errCode != ErrNoError {

--- a/core/transaction/pool/pool.go
+++ b/core/transaction/pool/pool.go
@@ -8,7 +8,6 @@ import (
 	"github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/core/ledger"
 	. "github.com/nknorg/nkn/core/transaction"
-	"github.com/nknorg/nkn/core/transaction/payload"
 	. "github.com/nknorg/nkn/errors"
 	"github.com/nknorg/nkn/por"
 	"github.com/nknorg/nkn/util/log"
@@ -22,15 +21,11 @@ type TxnPool struct {
 	sync.RWMutex
 	txnCnt        uint64                            // transaction count
 	txnList       map[common.Uint256]*Transaction   // transaction which have been verified will put into this map
-	issueSummary  map[common.Uint256]common.Fixed64 // transaction which pass the verify will summary the amout to this map
-	inputUTXOList map[string]*Transaction           // transaction which pass the verify will add the UTXO to this map
 }
 
 func NewTxnPool() *TxnPool {
 	return &TxnPool{
 		txnCnt:        0,
-		inputUTXOList: make(map[string]*Transaction),
-		issueSummary:  make(map[common.Uint256]common.Fixed64),
 		txnList:       make(map[common.Uint256]*Transaction),
 	}
 }
@@ -43,13 +38,17 @@ func (tp *TxnPool) AppendTxnPool(txn *Transaction) ErrCode {
 		log.Info("Transaction verification failed", txn.Hash())
 		return errCode
 	}
+	var txnList []*Transaction
+	for _, tx := range tp.txnList {
+		txnList = append(txnList, tx)
+	}
+	if errCode := VerifyTransactionWithBlock(txnList); errCode != ErrNoError {
+		log.Info("Transaction verification with block failed", txn.Hash())
+		return errCode
+	}
 	if errCode := VerifyTransactionWithLedger(txn); errCode != ErrNoError {
 		log.Info("Transaction verification with ledger failed", txn.Hash())
 		return errCode
-	}
-	//verify transaction by pool with lock
-	if ok := tp.verifyTransactionWithTxnPool(txn); !ok {
-		return ErrSummaryAsset
 	}
 
 	// get signature chain from commit transaction then add it to POR server
@@ -118,8 +117,6 @@ func (tp *TxnPool) GetTxnByCount(num int, winningHash common.Uint256) (map[commo
 //clean the trasaction Pool with committed block.
 func (tp *TxnPool) CleanSubmittedTransactions(txns []*Transaction) error {
 	tp.cleanTransactionList(txns)
-	tp.cleanUTXOList(txns)
-	tp.cleanIssueSummary(txns)
 	return nil
 }
 
@@ -140,119 +137,6 @@ func (tp *TxnPool) GetAllTransactions() map[common.Uint256]*Transaction {
 	}
 
 	return txns
-}
-
-//verify transaction with txnpool
-func (tp *TxnPool) verifyTransactionWithTxnPool(txn *Transaction) bool {
-	if err := tp.checkAndAddReferencedUTXO(txn); err != nil {
-		log.Warn("referenced UTXO already existed in transaction pool")
-		return false
-	}
-	//check issue transaction weather occur exceed issue range.
-	if ok := tp.summaryAssetIssueAmount(txn); !ok {
-		log.Info(fmt.Sprintf("Check summary Asset Issue Amount failed with txn=%x", txn.Hash()))
-		tp.removeTransaction(txn)
-		return false
-	}
-	return true
-}
-
-//remove from associated map
-func (tp *TxnPool) removeTransaction(txn *Transaction) {
-	//1.remove from txnList
-	tp.deltxnList(txn)
-	//2.remove from UTXO list map
-	result, err := txn.GetReference()
-	if err != nil {
-		log.Info(fmt.Sprintf("Transaction =%x not Exist in Pool when delete.", txn.Hash()))
-		return
-	}
-	for input := range result {
-		tp.delInputUTXOList(input)
-	}
-	//3.remove From Asset Issue Summary map
-	if txn.TxType != IssueAsset {
-		return
-	}
-	transactionResult := txn.GetMergedAssetIDValueFromOutputs()
-	for k, delta := range transactionResult {
-		tp.decrAssetIssueAmountSummary(k, delta)
-	}
-}
-
-//check and add to utxo list pool
-func (tp *TxnPool) checkAndAddReferencedUTXO(txn *Transaction) error {
-	reference, err := txn.GetReference()
-	if err != nil {
-		return err
-	}
-	txnHash := txn.Hash()
-	txnInputs := []*TxnInput{}
-	for k := range reference {
-		if tp.getInputUTXOList(k) != nil {
-			return fmt.Errorf("transaction: %s referenced a spent UTXO in transaction pool",
-				common.BytesToHexString(txnHash.ToArrayReverse()))
-		}
-		txnInputs = append(txnInputs, k)
-	}
-	for _, v := range txnInputs {
-		tp.addInputUTXOList(txn, v)
-	}
-
-	return nil
-}
-
-//clean txnpool utxo map
-func (tp *TxnPool) cleanUTXOList(txs []*Transaction) {
-	for _, txn := range txs {
-		inputUtxos, _ := txn.GetReference()
-		for Utxoinput, _ := range inputUtxos {
-			tp.delInputUTXOList(Utxoinput)
-		}
-	}
-}
-
-//check and summary to issue amount Pool
-func (tp *TxnPool) summaryAssetIssueAmount(txn *Transaction) bool {
-	if txn.TxType != IssueAsset {
-		return true
-	}
-	transactionResult := txn.GetMergedAssetIDValueFromOutputs()
-	for k, delta := range transactionResult {
-		//update the amount in txnPool
-		tp.incrAssetIssueAmountSummary(k, delta)
-
-		//Check weather occur exceed the amount when RegisterAsseted
-		//1. Get the Asset amount when RegisterAsseted.
-		txn, err := Store.GetTransaction(k)
-		if err != nil {
-			return false
-		}
-		if txn.TxType != RegisterAsset {
-			return false
-		}
-		AssetReg := txn.Payload.(*payload.RegisterAsset)
-
-		//2. Get the amount has been issued of tp assetID
-		var quantity_issued common.Fixed64
-		if AssetReg.Amount < common.Fixed64(0) {
-			continue
-		} else {
-			quantity_issued, err = Store.GetQuantityIssued(k)
-			if err != nil {
-				return false
-			}
-		}
-
-		//3. calc weather out off the amount when Registed.
-		//AssetReg.Amount : amount when RegisterAsset of tp assedID
-		//quantity_issued : amount has been issued of tp assedID
-		//txnPool.issueSummary[k] : amount in transactionPool of tp assedID
-		if AssetReg.Amount-quantity_issued < tp.getAssetIssueAmount(k) {
-			return false
-		}
-	}
-	return true
 }
 
 // clean the trasaction Pool with committed transactions.
@@ -294,88 +178,10 @@ func (tp *TxnPool) deltxnList(tx *Transaction) bool {
 	return true
 }
 
-func (tp *TxnPool) copytxnList() map[common.Uint256]*Transaction {
-	tp.RLock()
-	defer tp.RUnlock()
-	txnMap := make(map[common.Uint256]*Transaction, len(tp.txnList))
-	for txnId, txn := range tp.txnList {
-		txnMap[txnId] = txn
-	}
-	return txnMap
-}
-
 func (tp *TxnPool) GetTransactionCount() int {
 	tp.RLock()
 	defer tp.RUnlock()
 	return len(tp.txnList)
-}
-
-func (tp *TxnPool) getInputUTXOList(input *TxnInput) *Transaction {
-	tp.RLock()
-	defer tp.RUnlock()
-	return tp.inputUTXOList[input.ToString()]
-}
-
-func (tp *TxnPool) addInputUTXOList(tx *Transaction, input *TxnInput) bool {
-	tp.Lock()
-	defer tp.Unlock()
-	id := input.ToString()
-	_, ok := tp.inputUTXOList[id]
-	if ok {
-		return false
-	}
-	tp.inputUTXOList[id] = tx
-
-	return true
-}
-
-func (tp *TxnPool) delInputUTXOList(input *TxnInput) bool {
-	tp.Lock()
-	defer tp.Unlock()
-	id := input.ToString()
-	_, ok := tp.inputUTXOList[id]
-	if !ok {
-		return false
-	}
-	delete(tp.inputUTXOList, id)
-	return true
-}
-
-func (tp *TxnPool) incrAssetIssueAmountSummary(assetId common.Uint256, delta common.Fixed64) {
-	tp.Lock()
-	defer tp.Unlock()
-	tp.issueSummary[assetId] = tp.issueSummary[assetId] + delta
-}
-
-func (tp *TxnPool) decrAssetIssueAmountSummary(assetId common.Uint256, delta common.Fixed64) {
-	tp.Lock()
-	defer tp.Unlock()
-	amount, ok := tp.issueSummary[assetId]
-	if !ok {
-		return
-	}
-	amount = amount - delta
-	if amount < common.Fixed64(0) {
-		amount = common.Fixed64(0)
-	}
-	tp.issueSummary[assetId] = amount
-}
-
-func (tp *TxnPool) cleanIssueSummary(txs []*Transaction) {
-	for _, v := range txs {
-		if v.TxType == IssueAsset {
-			transactionResult := v.GetMergedAssetIDValueFromOutputs()
-			for k, delta := range transactionResult {
-				tp.decrAssetIssueAmountSummary(k, delta)
-			}
-		}
-	}
-}
-
-func (tp *TxnPool) getAssetIssueAmount(assetId common.Uint256) common.Fixed64 {
-	tp.RLock()
-	defer tp.RUnlock()
-	return tp.issueSummary[assetId]
 }
 
 func isHashExist(hash common.Uint256, hashSet []common.Uint256) bool {

--- a/core/transaction/pool/pool.go
+++ b/core/transaction/pool/pool.go
@@ -17,6 +17,19 @@ const (
 	ExclusivedSigchainHeight = 3
 )
 
+type TransactionMap map[common.Uint256]*Transaction
+
+func (iterable TransactionMap) Iterate(handler func(item *Transaction) interface{}) interface{} {
+	for _, item := range iterable {
+		result := handler(item)
+		if result != nil {
+			return result
+		}
+	}
+
+	return nil
+}
+
 type TxnPool struct {
 	sync.RWMutex
 	txnCnt        uint64                            // transaction count
@@ -38,11 +51,7 @@ func (tp *TxnPool) AppendTxnPool(txn *Transaction) ErrCode {
 		log.Info("Transaction verification failed", txn.Hash())
 		return errCode
 	}
-	var txnList []*Transaction
-	for _, tx := range tp.txnList {
-		txnList = append(txnList, tx)
-	}
-	if errCode := VerifyTransactionWithBlock(txnList); errCode != ErrNoError {
+	if errCode := VerifyTransactionWithBlock(TransactionMap(tp.txnList)); errCode != ErrNoError {
 		log.Info("Transaction verification with block failed", txn.Hash())
 		return errCode
 	}

--- a/core/transaction/pool/pool.go
+++ b/core/transaction/pool/pool.go
@@ -19,15 +19,15 @@ const (
 
 type TransactionMap map[common.Uint256]*Transaction
 
-func (iterable TransactionMap) Iterate(handler func(item *Transaction) interface{}) interface{} {
+func (iterable TransactionMap) Iterate(handler func(item *Transaction) ErrCode) ErrCode {
 	for _, item := range iterable {
 		result := handler(item)
-		if result != nil {
+		if result != ErrNoError {
 			return result
 		}
 	}
 
-	return nil
+	return ErrNoError
 }
 
 type TxnPool struct {


### PR DESCRIPTION
### Proposed changes in this pull request
Transactions should be validated with other transactions in pool/block when transaction is received or block is proposed/received/voted. Unify validation logic.

### Type
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)