### PR TITLE
verify duplicate name service operations in a block/pool

### DIFF
--- a/errors/errcode.go
+++ b/errors/errcode.go
@@ -27,6 +27,7 @@ const (
 	ErrSummaryAsset         ErrCode = 45012
 	ErrXmitFail             ErrCode = 45013
 	ErrNonOptimalSigChain   ErrCode = 45014
+	ErrDuplicateName        ErrCode = 45015
 )
 
 func (err ErrCode) Error() string {


### PR DESCRIPTION
### Proposed changes in this pull request
Right now name/registrant verification in name service happens only with ledger but not with the pool, because of this there could be two conflicting txs in a block that would cause problems when trying to persist this block.

### Type
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)