### PR TITLE
Bugfix for "drain 100% CPU" and "Syncing unexpected finish"

### DIFF
--- a/consensus/ising/proposerservice.go
+++ b/consensus/ising/proposerservice.go
@@ -163,7 +163,7 @@ func (ps *ProposerService) HandleBlockForking() {
 				}
 			}
 			// reset timer right away if no forking
-			timer.Reset(0)
+			timer.Reset(100 * time.Millisecond)
 		}
 	}
 }

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -464,10 +464,10 @@ func (node *node) WaitForSyncHeaderFinish(isProposer bool) {
 
 func (node *node) WaitForSyncBlkFinish() {
 	for {
-		headerHeight := ledger.DefaultLedger.Store.GetHeaderHeight()
 		currentBlkHeight := ledger.DefaultLedger.Blockchain.BlockHeight
-		log.Debug("WaitForSyncBlkFinish... current block height is ", currentBlkHeight, " ,current header height is ", headerHeight)
-		if currentBlkHeight >= headerHeight {
+		log.Debugf("WaitForSyncBlkFinish...\ncurrent block %v, expect hash %x", currentBlkHeight, node.syncStopHash)
+		blk, err := ledger.DefaultLedger.Store.GetBlock(node.syncStopHash)
+		if err == nil && blk != nil {
 			break
 		}
 		<-time.After(2 * time.Second)


### PR DESCRIPTION
### Proposed changes in this pull request
#### Two Bugfix:
* Avoid drain 100% CPU
PingPong service has 0 duration if node at PersistFinished SyncState. It wil drain 100% CPU.
* Stringent condition of WaitForSyncBlkFinish
Sync routine will unexpected finish if incorrect Chain higher then target Chain
Use compare BlkHash instead of compare BlkHeight as SyncFinished condition

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
