### PR TITLE
[bugfix] racy use of timers

### DIFF
--- a/consensus/ising/proposerservice.go
+++ b/consensus/ising/proposerservice.go
@@ -41,6 +41,7 @@ type ProposerService struct {
 	mining               Mining                    // built-in mining
 	consensusMsgReceived events.Subscriber         // consensus events listening
 	blockPersisted       events.Subscriber         // block saved events
+	blockPersistedLock   sync.RWMutex              // block persisted lock
 	syncFinished         events.Subscriber         // block syncing finished event
 	forkCache            *ForkCache                // cache for handling block forking
 	proposerCache        *ProposerCache            // cache for block proposer
@@ -379,6 +380,9 @@ func (ps *ProposerService) TimeoutRoutine() {
 }
 
 func (ps *ProposerService) BlockPersistCompleted(v interface{}) {
+	ps.blockPersistedLock.Lock()
+	defer ps.blockPersistedLock.Unlock()
+
 	// reset timer when block persisted
 	ps.proposerChangeTimer.Stop()
 	ps.proposerChangeTimer.Reset(config.ProposerChangeTime)


### PR DESCRIPTION
cause: When block is persisted, BlockPersistCompleted will be call as a
goroutine. If multiple BlockPersistCompleted goroutines execute
ps.ProposerChangeTimer.Reset() function At the same time, it will appear race.

add a mutex lock in BlockPersistCompleted to avoid above situation.

Signed-off-by: NoelBright <noel.n.bright@gmail.com>

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
