### PR TITLE
Fix msg broascast loop and rename pb

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 486c72d81aa3d9af18bec54daa5210958567a0cb453edc3394f41f19d91af568
-updated: 2018-11-01T00:38:04.058338-07:00
+updated: 2018-11-01T15:22:27.530758-07:00
 imports:
 - name: github.com/gogo/protobuf
   version: 636bf0302bc95575d69441b25a2603156ffdddf1
@@ -55,7 +55,7 @@ imports:
 - name: github.com/nknorg/gopass
   version: 9ddc09fe41c891b7987acd1bf75f9067a56c17f5
 - name: github.com/nknorg/nnet
-  version: 1b555112dcec4cb9a581697d51bb3162d976320a
+  version: 5a55ac766559eb42facbe7c208a1e7c89a1a876e
   subpackages:
   - cache
   - common
@@ -121,7 +121,7 @@ imports:
   - twofish
   - xtea
 - name: golang.org/x/net
-  version: c44066c5c816ec500d459a2a324a753f78531ae0
+  version: e11730110bbd884bbf19550bfafe9d69519ce29e
   repo: https://github.com/golang/net
   vcs: git
   subpackages:

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -50,7 +50,7 @@ const (
 
 type node struct {
 	sync.Mutex
-	protobuf.Node
+	protobuf.NodeData
 	id            uint64         // node ID
 	version       uint32         // network protocol version
 	height        uint32         // node latest block height
@@ -144,7 +144,7 @@ func InitNode(pubKey *crypto.PubKey, nn *nnet.NNet) (Noder, error) {
 	n.hashCache = NewHashCache()
 	n.nnet = nn
 
-	nn.GetLocalNode().Node.Data, err = proto.Marshal(&n.Node)
+	nn.GetLocalNode().Node.Data, err = proto.Marshal(&n.NodeData)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +294,7 @@ func (n *node) AddRemoteNode(remoteNode *nnetnode.RemoteNode) error {
 		return err
 	}
 
-	err = proto.Unmarshal(remoteNode.Node.Data, &node.Node)
+	err = proto.Unmarshal(remoteNode.Node.Data, &node.NodeData)
 	if err != nil {
 		return err
 	}
@@ -652,7 +652,7 @@ func (node *node) FindWsAddr(key []byte) (string, error) {
 	}
 
 	pred := preds[0]
-	nodeData := &protobuf.Node{}
+	nodeData := &protobuf.NodeData{}
 	err = proto.Unmarshal(pred.Data, nodeData)
 	if err != nil {
 		return "", err

--- a/protobuf/node.pb.go
+++ b/protobuf/node.pb.go
@@ -26,23 +26,23 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
-type Node struct {
+type NodeData struct {
 	PublicKey     []byte `protobuf:"bytes,1,opt,name=public_key,json=publicKey,proto3" json:"public_key,omitempty"`
 	WebsocketPort uint32 `protobuf:"varint,2,opt,name=websocket_port,json=websocketPort,proto3" json:"websocket_port,omitempty"`
 	JsonRpcPort   uint32 `protobuf:"varint,3,opt,name=json_rpc_port,json=jsonRpcPort,proto3" json:"json_rpc_port,omitempty"`
 }
 
-func (m *Node) Reset()      { *m = Node{} }
-func (*Node) ProtoMessage() {}
-func (*Node) Descriptor() ([]byte, []int) {
-	return fileDescriptor_node_ce21960e9e727bba, []int{0}
+func (m *NodeData) Reset()      { *m = NodeData{} }
+func (*NodeData) ProtoMessage() {}
+func (*NodeData) Descriptor() ([]byte, []int) {
+	return fileDescriptor_node_e8125dfef5c97b67, []int{0}
 }
-func (m *Node) XXX_Unmarshal(b []byte) error {
+func (m *NodeData) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *Node) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *NodeData) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_Node.Marshal(b, m, deterministic)
+		return xxx_messageInfo_NodeData.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalTo(b)
@@ -52,33 +52,33 @@ func (m *Node) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (dst *Node) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Node.Merge(dst, src)
+func (dst *NodeData) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_NodeData.Merge(dst, src)
 }
-func (m *Node) XXX_Size() int {
+func (m *NodeData) XXX_Size() int {
 	return m.Size()
 }
-func (m *Node) XXX_DiscardUnknown() {
-	xxx_messageInfo_Node.DiscardUnknown(m)
+func (m *NodeData) XXX_DiscardUnknown() {
+	xxx_messageInfo_NodeData.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_Node proto.InternalMessageInfo
+var xxx_messageInfo_NodeData proto.InternalMessageInfo
 
-func (m *Node) GetPublicKey() []byte {
+func (m *NodeData) GetPublicKey() []byte {
 	if m != nil {
 		return m.PublicKey
 	}
 	return nil
 }
 
-func (m *Node) GetWebsocketPort() uint32 {
+func (m *NodeData) GetWebsocketPort() uint32 {
 	if m != nil {
 		return m.WebsocketPort
 	}
 	return 0
 }
 
-func (m *Node) GetJsonRpcPort() uint32 {
+func (m *NodeData) GetJsonRpcPort() uint32 {
 	if m != nil {
 		return m.JsonRpcPort
 	}
@@ -86,16 +86,16 @@ func (m *Node) GetJsonRpcPort() uint32 {
 }
 
 func init() {
-	proto.RegisterType((*Node)(nil), "protobuf.Node")
+	proto.RegisterType((*NodeData)(nil), "protobuf.NodeData")
 }
-func (this *Node) Equal(that interface{}) bool {
+func (this *NodeData) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
 	}
 
-	that1, ok := that.(*Node)
+	that1, ok := that.(*NodeData)
 	if !ok {
-		that2, ok := that.(Node)
+		that2, ok := that.(NodeData)
 		if ok {
 			that1 = &that2
 		} else {
@@ -118,12 +118,12 @@ func (this *Node) Equal(that interface{}) bool {
 	}
 	return true
 }
-func (this *Node) GoString() string {
+func (this *NodeData) GoString() string {
 	if this == nil {
 		return "nil"
 	}
 	s := make([]string, 0, 7)
-	s = append(s, "&protobuf.Node{")
+	s = append(s, "&protobuf.NodeData{")
 	s = append(s, "PublicKey: "+fmt.Sprintf("%#v", this.PublicKey)+",\n")
 	s = append(s, "WebsocketPort: "+fmt.Sprintf("%#v", this.WebsocketPort)+",\n")
 	s = append(s, "JsonRpcPort: "+fmt.Sprintf("%#v", this.JsonRpcPort)+",\n")
@@ -138,7 +138,7 @@ func valueToGoStringNode(v interface{}, typ string) string {
 	pv := reflect.Indirect(rv).Interface()
 	return fmt.Sprintf("func(v %v) *%v { return &v } ( %#v )", typ, typ, pv)
 }
-func (m *Node) Marshal() (dAtA []byte, err error) {
+func (m *NodeData) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalTo(dAtA)
@@ -148,7 +148,7 @@ func (m *Node) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *Node) MarshalTo(dAtA []byte) (int, error) {
+func (m *NodeData) MarshalTo(dAtA []byte) (int, error) {
 	var i int
 	_ = i
 	var l int
@@ -181,8 +181,8 @@ func encodeVarintNode(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return offset + 1
 }
-func NewPopulatedNode(r randyNode, easy bool) *Node {
-	this := &Node{}
+func NewPopulatedNodeData(r randyNode, easy bool) *NodeData {
+	this := &NodeData{}
 	v1 := r.Intn(100)
 	this.PublicKey = make([]byte, v1)
 	for i := 0; i < v1; i++ {
@@ -267,7 +267,7 @@ func encodeVarintPopulateNode(dAtA []byte, v uint64) []byte {
 	dAtA = append(dAtA, uint8(v))
 	return dAtA
 }
-func (m *Node) Size() (n int) {
+func (m *NodeData) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -299,11 +299,11 @@ func sovNode(x uint64) (n int) {
 func sozNode(x uint64) (n int) {
 	return sovNode(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-func (this *Node) String() string {
+func (this *NodeData) String() string {
 	if this == nil {
 		return "nil"
 	}
-	s := strings.Join([]string{`&Node{`,
+	s := strings.Join([]string{`&NodeData{`,
 		`PublicKey:` + fmt.Sprintf("%v", this.PublicKey) + `,`,
 		`WebsocketPort:` + fmt.Sprintf("%v", this.WebsocketPort) + `,`,
 		`JsonRpcPort:` + fmt.Sprintf("%v", this.JsonRpcPort) + `,`,
@@ -319,7 +319,7 @@ func valueToStringNode(v interface{}) string {
 	pv := reflect.Indirect(rv).Interface()
 	return fmt.Sprintf("*%v", pv)
 }
-func (m *Node) Unmarshal(dAtA []byte) error {
+func (m *NodeData) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -342,10 +342,10 @@ func (m *Node) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: Node: wiretype end group for non-group")
+			return fmt.Errorf("proto: NodeData: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: Node: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: NodeData: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
@@ -543,23 +543,23 @@ var (
 	ErrIntOverflowNode   = fmt.Errorf("proto: integer overflow")
 )
 
-func init() { proto.RegisterFile("protobuf/node.proto", fileDescriptor_node_ce21960e9e727bba) }
+func init() { proto.RegisterFile("protobuf/node.proto", fileDescriptor_node_e8125dfef5c97b67) }
 
-var fileDescriptor_node_ce21960e9e727bba = []byte{
-	// 235 bytes of a gzipped FileDescriptorProto
+var fileDescriptor_node_e8125dfef5c97b67 = []byte{
+	// 239 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x2e, 0x28, 0xca, 0x2f,
 	0xc9, 0x4f, 0x2a, 0x4d, 0xd3, 0xcf, 0xcb, 0x4f, 0x49, 0xd5, 0x03, 0xf3, 0x84, 0x38, 0x60, 0x82,
 	0x52, 0xba, 0xe9, 0x99, 0x25, 0x19, 0xa5, 0x49, 0x7a, 0xc9, 0xf9, 0xb9, 0xfa, 0xe9, 0xf9, 0xe9,
-	0xf9, 0xfa, 0x70, 0xe5, 0x20, 0x1e, 0x98, 0x03, 0x66, 0x41, 0x34, 0x2a, 0x15, 0x70, 0xb1, 0xf8,
-	0xe5, 0xa7, 0xa4, 0x0a, 0xc9, 0x72, 0x71, 0x15, 0x94, 0x26, 0xe5, 0x64, 0x26, 0xc7, 0x67, 0xa7,
-	0x56, 0x4a, 0x30, 0x2a, 0x30, 0x6a, 0xf0, 0x04, 0x71, 0x42, 0x44, 0xbc, 0x53, 0x2b, 0x85, 0x54,
-	0xb9, 0xf8, 0xca, 0x53, 0x93, 0x8a, 0xf3, 0x93, 0xb3, 0x53, 0x4b, 0xe2, 0x0b, 0xf2, 0x8b, 0x4a,
-	0x24, 0x98, 0x14, 0x18, 0x35, 0x78, 0x83, 0x78, 0xe1, 0xa2, 0x01, 0xf9, 0x45, 0x25, 0x42, 0x4a,
-	0x5c, 0xbc, 0x59, 0xc5, 0xf9, 0x79, 0xf1, 0x45, 0x05, 0xc9, 0x10, 0x55, 0xcc, 0x60, 0x55, 0xdc,
-	0x20, 0xc1, 0xa0, 0x82, 0x64, 0x90, 0x1a, 0x27, 0x9b, 0x0b, 0x0f, 0xe5, 0x18, 0x6e, 0x3c, 0x94,
-	0x63, 0xf8, 0xf0, 0x50, 0x8e, 0xf1, 0xc7, 0x43, 0x39, 0xc6, 0x86, 0x47, 0x72, 0x8c, 0x2b, 0x1e,
-	0xc9, 0x31, 0xee, 0x78, 0x24, 0xc7, 0x78, 0xe2, 0x91, 0x1c, 0xe3, 0x85, 0x47, 0x72, 0x8c, 0x0f,
-	0x1e, 0xc9, 0x31, 0xbe, 0x78, 0x24, 0xc7, 0xf0, 0xe1, 0x91, 0x1c, 0xe3, 0x84, 0xc7, 0x72, 0x0c,
-	0x17, 0x1e, 0xcb, 0x31, 0xdc, 0x78, 0x2c, 0xc7, 0x90, 0xc4, 0x06, 0x76, 0xb6, 0x31, 0x20, 0x00,
-	0x00, 0xff, 0xff, 0x89, 0xa0, 0x43, 0x9f, 0x06, 0x01, 0x00, 0x00,
+	0xf9, 0xfa, 0x70, 0xe5, 0x20, 0x1e, 0x98, 0x03, 0x66, 0x41, 0x34, 0x2a, 0x95, 0x70, 0x71, 0xf8,
+	0xe5, 0xa7, 0xa4, 0xba, 0x24, 0x96, 0x24, 0x0a, 0xc9, 0x72, 0x71, 0x15, 0x94, 0x26, 0xe5, 0x64,
+	0x26, 0xc7, 0x67, 0xa7, 0x56, 0x4a, 0x30, 0x2a, 0x30, 0x6a, 0xf0, 0x04, 0x71, 0x42, 0x44, 0xbc,
+	0x53, 0x2b, 0x85, 0x54, 0xb9, 0xf8, 0xca, 0x53, 0x93, 0x8a, 0xf3, 0x93, 0xb3, 0x53, 0x4b, 0xe2,
+	0x0b, 0xf2, 0x8b, 0x4a, 0x24, 0x98, 0x14, 0x18, 0x35, 0x78, 0x83, 0x78, 0xe1, 0xa2, 0x01, 0xf9,
+	0x45, 0x25, 0x42, 0x4a, 0x5c, 0xbc, 0x59, 0xc5, 0xf9, 0x79, 0xf1, 0x45, 0x05, 0xc9, 0x10, 0x55,
+	0xcc, 0x60, 0x55, 0xdc, 0x20, 0xc1, 0xa0, 0x82, 0x64, 0x90, 0x1a, 0x27, 0x9b, 0x0b, 0x0f, 0xe5,
+	0x18, 0x6e, 0x3c, 0x94, 0x63, 0xf8, 0xf0, 0x50, 0x8e, 0xf1, 0xc7, 0x43, 0x39, 0xc6, 0x86, 0x47,
+	0x72, 0x8c, 0x2b, 0x1e, 0xc9, 0x31, 0xee, 0x78, 0x24, 0xc7, 0x78, 0xe2, 0x91, 0x1c, 0xe3, 0x85,
+	0x47, 0x72, 0x8c, 0x0f, 0x1e, 0xc9, 0x31, 0xbe, 0x78, 0x24, 0xc7, 0xf0, 0xe1, 0x91, 0x1c, 0xe3,
+	0x84, 0xc7, 0x72, 0x0c, 0x17, 0x1e, 0xcb, 0x31, 0xdc, 0x78, 0x2c, 0xc7, 0x90, 0xc4, 0x06, 0x76,
+	0xba, 0x31, 0x20, 0x00, 0x00, 0xff, 0xff, 0x40, 0xb5, 0xee, 0x56, 0x0a, 0x01, 0x00, 0x00,
 }

--- a/protobuf/node.proto
+++ b/protobuf/node.proto
@@ -15,7 +15,7 @@ option (gogoproto.testgen_all) = true;
 option (gogoproto.equal_all) = true;
 option (gogoproto.populate_all) = true;
 
-message Node {
+message NodeData {
   bytes public_key = 1;
   uint32 websocket_port = 2;
   uint32 json_rpc_port = 3;

--- a/protobuf/nodepb_test.go
+++ b/protobuf/nodepb_test.go
@@ -19,15 +19,15 @@ var _ = proto.Marshal
 var _ = fmt.Errorf
 var _ = math.Inf
 
-func TestNodeProto(t *testing.T) {
+func TestNodeDataProto(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedNode(popr, false)
+	p := NewPopulatedNodeData(popr, false)
 	dAtA, err := github_com_gogo_protobuf_proto.Marshal(p)
 	if err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
-	msg := &Node{}
+	msg := &NodeData{}
 	if err := github_com_gogo_protobuf_proto.Unmarshal(dAtA, msg); err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
@@ -50,10 +50,10 @@ func TestNodeProto(t *testing.T) {
 	}
 }
 
-func TestNodeMarshalTo(t *testing.T) {
+func TestNodeDataMarshalTo(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedNode(popr, false)
+	p := NewPopulatedNodeData(popr, false)
 	size := p.Size()
 	dAtA := make([]byte, size)
 	for i := range dAtA {
@@ -63,7 +63,7 @@ func TestNodeMarshalTo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
-	msg := &Node{}
+	msg := &NodeData{}
 	if err := github_com_gogo_protobuf_proto.Unmarshal(dAtA, msg); err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
@@ -75,16 +75,16 @@ func TestNodeMarshalTo(t *testing.T) {
 	}
 }
 
-func TestNodeJSON(t *testing.T) {
+func TestNodeDataJSON(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedNode(popr, true)
+	p := NewPopulatedNodeData(popr, true)
 	marshaler := github_com_gogo_protobuf_jsonpb.Marshaler{}
 	jsondata, err := marshaler.MarshalToString(p)
 	if err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
-	msg := &Node{}
+	msg := &NodeData{}
 	err = github_com_gogo_protobuf_jsonpb.UnmarshalString(jsondata, msg)
 	if err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
@@ -93,12 +93,12 @@ func TestNodeJSON(t *testing.T) {
 		t.Fatalf("seed = %d, %#v !Json Equal %#v", seed, msg, p)
 	}
 }
-func TestNodeProtoText(t *testing.T) {
+func TestNodeDataProtoText(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedNode(popr, true)
+	p := NewPopulatedNodeData(popr, true)
 	dAtA := github_com_gogo_protobuf_proto.MarshalTextString(p)
-	msg := &Node{}
+	msg := &NodeData{}
 	if err := github_com_gogo_protobuf_proto.UnmarshalText(dAtA, msg); err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
@@ -107,12 +107,12 @@ func TestNodeProtoText(t *testing.T) {
 	}
 }
 
-func TestNodeProtoCompactText(t *testing.T) {
+func TestNodeDataProtoCompactText(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedNode(popr, true)
+	p := NewPopulatedNodeData(popr, true)
 	dAtA := github_com_gogo_protobuf_proto.CompactTextString(p)
-	msg := &Node{}
+	msg := &NodeData{}
 	if err := github_com_gogo_protobuf_proto.UnmarshalText(dAtA, msg); err != nil {
 		t.Fatalf("seed = %d, err = %v", seed, err)
 	}
@@ -121,9 +121,9 @@ func TestNodeProtoCompactText(t *testing.T) {
 	}
 }
 
-func TestNodeGoString(t *testing.T) {
+func TestNodeDataGoString(t *testing.T) {
 	popr := math_rand.New(math_rand.NewSource(time.Now().UnixNano()))
-	p := NewPopulatedNode(popr, false)
+	p := NewPopulatedNodeData(popr, false)
 	s1 := p.GoString()
 	s2 := fmt.Sprintf("%#v", p)
 	if s1 != s2 {
@@ -134,10 +134,10 @@ func TestNodeGoString(t *testing.T) {
 		t.Fatal(err)
 	}
 }
-func TestNodeSize(t *testing.T) {
+func TestNodeDataSize(t *testing.T) {
 	seed := time.Now().UnixNano()
 	popr := math_rand.New(math_rand.NewSource(seed))
-	p := NewPopulatedNode(popr, true)
+	p := NewPopulatedNodeData(popr, true)
 	size2 := github_com_gogo_protobuf_proto.Size(p)
 	dAtA, err := github_com_gogo_protobuf_proto.Marshal(p)
 	if err != nil {
@@ -156,9 +156,9 @@ func TestNodeSize(t *testing.T) {
 	}
 }
 
-func TestNodeStringer(t *testing.T) {
+func TestNodeDataStringer(t *testing.T) {
 	popr := math_rand.New(math_rand.NewSource(time.Now().UnixNano()))
-	p := NewPopulatedNode(popr, false)
+	p := NewPopulatedNodeData(popr, false)
 	s1 := p.String()
 	s2 := fmt.Sprintf("%v", p)
 	if s1 != s2 {


### PR DESCRIPTION
* Use new nnet version to prevent loop
* Rename protobuf.Node to protobuf.NodeData to avoid name conflict

Signed-off-by: Yilun <zyl.skysniper@gmail.com>

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
