### PR TITLE
Configure an extra address to receive the reward of the mining

### DIFF
--- a/consensus/ising/mining.go
+++ b/consensus/ising/mining.go
@@ -18,8 +18,8 @@ import (
 )
 
 type Mining interface {
-	BuildBlock(height uint32, chordID []byte, winningHash Uint256,
-		winningHashType ledger.WinningHashType) (*ledger.Block, error)
+	BuildBlock(height uint32, chordID []byte, winnerHash Uint256,
+		winnerType ledger.WinnerType) (*ledger.Block, error)
 }
 
 type BuiltinMining struct {
@@ -35,14 +35,14 @@ func NewBuiltinMining(account *vault.Account, txnCollector *transaction.TxnColle
 	}
 }
 
-func (bm *BuiltinMining) BuildBlock(height uint32, chordID []byte, winningHash Uint256,
-	winningHashType ledger.WinningHashType) (*ledger.Block, error) {
+func (bm *BuiltinMining) BuildBlock(height uint32, chordID []byte, winnerHash Uint256,
+	winnerType ledger.WinnerType) (*ledger.Block, error) {
 	var txnList []*transaction.Transaction
 	var txnHashList []Uint256
 	coinbase := bm.CreateCoinbaseTransaction()
 	txnList = append(txnList, coinbase)
 	txnHashList = append(txnHashList, coinbase.Hash())
-	txns, err := bm.txnCollector.Collect(winningHash)
+	txns, err := bm.txnCollector.Collect(winnerHash)
 	if err != nil {
 		log.Error("collect transaction error: ", err)
 		return nil, err
@@ -69,8 +69,8 @@ func (bm *BuiltinMining) BuildBlock(height uint32, chordID []byte, winningHash U
 		ConsensusData:    rand.Uint64(),
 		TransactionsRoot: txnRoot,
 		NextBookKeeper:   Uint160{},
-		WinningHash:      winningHash,
-		WinningHashType:  winningHashType,
+		WinnerHash:       winnerHash,
+		WinnerType:	  winnerType,
 		Signer:           encodedPubKey,
 		ChordID:          chordID,
 		Signature:        nil,
@@ -95,6 +95,17 @@ func (bm *BuiltinMining) BuildBlock(height uint32, chordID []byte, winningHash U
 }
 
 func (bm *BuiltinMining) CreateCoinbaseTransaction() *transaction.Transaction {
+	// Transfer the reward to the beneficiary
+	redeemHash := bm.account.ProgramHash
+	if (config.Parameters.BeneficiaryAddr != "") {
+		hash, err := ToScriptHash(config.Parameters.BeneficiaryAddr)
+		if err == nil {
+			redeemHash = hash
+		} else {
+			log.Error("%v\n%s", err, "Beneficiary account redeemhash convert failed")
+		}
+	}
+
 	return &transaction.Transaction{
 		TxType:         transaction.Coinbase,
 		PayloadVersion: 0,
@@ -110,7 +121,7 @@ func (bm *BuiltinMining) CreateCoinbaseTransaction() *transaction.Transaction {
 			{
 				AssetID:     ledger.DefaultLedger.Blockchain.AssetID,
 				Value:       Fixed64 (config.DefaultMiningReward * StorageFactor),
-				ProgramHash: bm.account.ProgramHash,
+				ProgramHash: redeemHash,
 			},
 		},
 		Programs: []*program.Program{},

--- a/consensus/ising/proposercache.go
+++ b/consensus/ising/proposercache.go
@@ -21,8 +21,8 @@ const (
 type ProposerInfo struct {
 	publicKey       []byte
 	chordID         []byte
-	winningHash     Uint256
-	winningHashType ledger.WinningHashType
+	winnerHash      Uint256
+	winnerType      ledger.WinnerType
 }
 
 type ProposerCache struct {
@@ -49,8 +49,8 @@ func (pc *ProposerCache) Add(height uint32, votingContent voting.VotingContent) 
 		proposerInfo = &ProposerInfo{
 			publicKey:       pbk,
 			chordID:         id,
-			winningHash:     t.Hash(),
-			winningHashType: ledger.WinningBlockHash,
+			winnerHash:      t.Hash(),
+			winnerType:      ledger.BlockSigner,
 		}
 		log.Warningf("use proposer of block height %d which public key is %s chord ID is %s to propose block %d",
 			t.Header.Height, BytesToHexString(pbk), BytesToHexString(id), height)
@@ -64,10 +64,10 @@ func (pc *ProposerCache) Add(height uint32, votingContent voting.VotingContent) 
 			return
 		}
 		proposerInfo = &ProposerInfo{
-			publicKey:       pbk,
-			chordID:         id,
-			winningHash:     t.Hash(),
-			winningHashType: ledger.WinningTxnHash,
+			publicKey:      pbk,
+			chordID:        id,
+			winnerHash:	t.Hash(),
+			winnerType:	ledger.TxnSigner,
 		}
 		sigChainTxnHash := t.Hash()
 		log.Infof("sigchain transaction consensus: %s, %s will be block proposer for height %d",
@@ -85,9 +85,9 @@ func (pc *ProposerCache) Get(height uint32) *ProposerInfo {
 	if height < InitialBlockHeight {
 		proposer, _ := HexStringToBytes(config.Parameters.GenesisBlockProposer)
 		return &ProposerInfo{
-			publicKey:       proposer,
-			winningHash:     EmptyUint256,
-			winningHashType: ledger.GenesisHash,
+			publicKey:      proposer,
+			winnerHash:     EmptyUint256,
+			winnerType:	ledger.GenesisSigner,
 		}
 	}
 

--- a/consensus/ising/proposerservice.go
+++ b/consensus/ising/proposerservice.go
@@ -297,16 +297,16 @@ func (ps *ProposerService) SendNewProposal(votingHeight uint32, vType voting.Vot
 func (ps *ProposerService) ProduceNewBlock() {
 	current := ps.CurrentVoting(voting.BlockVote)
 	votingHeight := current.GetVotingHeight()
-	proposerInfo := ps.proposerCache.Get(votingHeight + 1)
-	if proposerInfo == nil {
-		proposerInfo = &ProposerInfo{
-			winningHash:     EmptyUint256,
-			winningHashType: ledger.WinningBlockHash,
+	info := ps.proposerCache.Get(votingHeight + 1)
+	if info == nil {
+		info = &ProposerInfo{
+			winnerHash:	EmptyUint256,
+			winnerType:	ledger.BlockSigner,
 		}
 	}
 	// build new block to be proposed
 	block, err := ps.mining.BuildBlock(votingHeight, ps.localNode.GetChordAddr(),
-		proposerInfo.winningHash, proposerInfo.winningHashType)
+		info.winnerHash, info.winnerType)
 	if err != nil {
 		log.Error("building block error: ", err)
 	}

--- a/core/ledger/header.go
+++ b/core/ledger/header.go
@@ -14,16 +14,16 @@ import (
 	. "github.com/nknorg/nkn/errors"
 )
 
-type WinningHashType byte
+type WinnerType byte
 
 const (
 	// The proof of Block proposer validity should exists in previous Block header.
 	// GenesisHash means next Block proposer is GenesisBlockProposer.
-	GenesisHash WinningHashType = 0
+	GenesisSigner WinnerType = 0
 	// WinningTxnHash means next Block proposer is a node on signature chain.
-	WinningTxnHash WinningHashType = 1
+	TxnSigner     WinnerType = 1
 	// WinningBlockHash means next Block proposer is signer of historical Block.
-	WinningBlockHash WinningHashType = 2
+	BlockSigner   WinnerType = 2
 )
 
 const (
@@ -39,8 +39,8 @@ type Header struct {
 	Height           uint32
 	ConsensusData    uint64
 	NextBookKeeper   Uint160
-	WinningHash      Uint256
-	WinningHashType  WinningHashType
+	WinnerHash       Uint256
+	WinnerType	 WinnerType
 	Signer           []byte
 	ChordID          []byte
 	Signature        []byte
@@ -68,8 +68,8 @@ func (h *Header) SerializeUnsigned(w io.Writer) error {
 	serialization.WriteUint32(w, h.Height)
 	serialization.WriteUint64(w, h.ConsensusData)
 	h.NextBookKeeper.Serialize(w)
-	h.WinningHash.Serialize(w)
-	serialization.WriteByte(w, byte(h.WinningHashType))
+	h.WinnerHash.Serialize(w)
+	serialization.WriteByte(w, byte(h.WinnerType))
 	serialization.WriteVarBytes(w, h.Signer)
 	if h.Version == HeaderVersion {
 		serialization.WriteVarBytes(w, h.ChordID)
@@ -139,13 +139,13 @@ func (h *Header) DeserializeUnsigned(r io.Reader) error {
 	//NextBookKeeper
 	h.NextBookKeeper.Deserialize(r)
 
-	h.WinningHash.Deserialize(r)
+	h.WinnerHash.Deserialize(r)
 
 	t, err := serialization.ReadByte(r)
 	if err != nil {
 		return err
 	}
-	h.WinningHashType = WinningHashType(t)
+	h.WinnerType = WinnerType(t)
 
 	h.Signer, err = serialization.ReadVarBytes(r)
 	if err != nil {
@@ -225,8 +225,8 @@ func (h *Header) MarshalJson() ([]byte, error) {
 		Height:           h.Height,
 		ConsensusData:    h.ConsensusData,
 		NextBookKeeper:   BytesToHexString(h.NextBookKeeper.ToArrayReverse()),
-		WinningHash:      BytesToHexString(h.WinningHash.ToArrayReverse()),
-		WinningHashType:  byte(h.WinningHashType),
+		WinnerHash:       BytesToHexString(h.WinnerHash.ToArrayReverse()),
+		WinnerType:	  byte(h.WinnerType),
 		Signer:           BytesToHexString(h.Signer),
 		ChordID:          BytesToHexString(h.ChordID),
 		Signature:        BytesToHexString(h.Signature),
@@ -257,7 +257,7 @@ func (h *Header) UnmarshalJson(data []byte) error {
 	h.Timestamp = headerInfo.Timestamp
 	h.Height = headerInfo.Height
 	h.ConsensusData = headerInfo.ConsensusData
-	h.WinningHashType = WinningHashType(headerInfo.WinningHashType)
+	h.WinnerType = WinnerType(headerInfo.WinnerType)
 
 	prevHash, err := HexStringToBytesReverse(headerInfo.PrevBlockHash)
 	if err != nil {
@@ -286,11 +286,11 @@ func (h *Header) UnmarshalJson(data []byte) error {
 		return err
 	}
 
-	winHash, err := HexStringToBytesReverse(headerInfo.WinningHash)
+	winHash, err := HexStringToBytesReverse(headerInfo.WinnerHash)
 	if err != nil {
 		return err
 	}
-	h.WinningHash, err = Uint256ParseFromBytes(winHash)
+	h.WinnerHash, err = Uint256ParseFromBytes(winHash)
 	if err != nil {
 		return err
 	}

--- a/core/ledger/jsontype.go
+++ b/core/ledger/jsontype.go
@@ -13,8 +13,8 @@ type HeaderInfo struct {
 	Height           uint32              `json:"height"`
 	ConsensusData    uint64              `json:"consensusData"`
 	NextBookKeeper   string              `json:"nextBookKeeper"`
-	WinningHash      string              `json:"winningHash"`
-	WinningHashType  byte                `json:"winningHashType"`
+	WinnerHash       string              `json:"winningHash"`
+	WinnerType       byte                `json:"winningHashType"`
 	Signer           string              `json:"signer"`
 	ChordID          string              `json:"chordID"`
 	Signature        string              `json:"signature"`

--- a/core/ledger/validator.go
+++ b/core/ledger/validator.go
@@ -83,7 +83,7 @@ func HeaderCheck(header *Header, receiveTime int64) error {
 	if prevHeader.Timestamp >= header.Timestamp {
 		return errors.New("invalid header timestamp")
 	}
-	if header.WinningHashType == GenesisHash && header.Height >= GenesisBlockProposedHeight {
+	if header.WinnerType == GenesisSigner && header.Height >= GenesisBlockProposedHeight {
 		return errors.New("invalid winning hash type")
 	}
 
@@ -135,18 +135,18 @@ func HeaderCheck(header *Header, receiveTime int64) error {
 			return err
 		}
 	} else {
-		winningHash := prevHeader.WinningHash
-		winningHashType := prevHeader.WinningHashType
-		switch winningHashType {
-		case GenesisHash:
+		winnerHash := prevHeader.WinnerHash
+		winnerType := prevHeader.WinnerType
+		switch winnerType {
+		case GenesisSigner:
 			publicKey, chordID, err = genesisBlock.GetSigner()
 			if err != nil {
 				return err
 			}
 			log.Infof("block signer: public key should be %s, which is genesis block proposer",
 				BytesToHexString(publicKey))
-		case WinningTxnHash:
-			txn, err := DefaultLedger.Store.GetTransaction(winningHash)
+		case TxnSigner:
+			txn, err := DefaultLedger.Store.GetTransaction(winnerHash)
 			if err != nil {
 				return err
 			}

--- a/core/transaction/transaction.go
+++ b/core/transaction/transaction.go
@@ -297,16 +297,12 @@ func (tx *Transaction) GetProgramHashes() ([]Uint160, error) {
 	switch tx.TxType {
 	case RegisterAsset:
 		issuer := tx.Payload.(*payload.RegisterAsset).Issuer
-		signatureRedeemScript, err := contract.CreateSignatureRedeemScript(issuer)
-		if err != nil {
-			return nil, NewDetailErr(err, ErrNoCode, "[Transaction], GetProgramHashes CreateSignatureRedeemScript failed.")
-		}
 
-		astHash, err := ToCodeHash(signatureRedeemScript)
+		hash, err := contract.CreateRedeemHash(issuer)
 		if err != nil {
-			return nil, NewDetailErr(err, ErrNoCode, "[Transaction], GetProgramHashes ToCodeHash failed.")
+			return nil, fmt.Errorf("%v\n%s", err, "[Transaction] GetProgramHashes Signature register hash generated failed")
 		}
-		hashs = append(hashs, astHash)
+		hashs = append(hashs, hash)
 	case IssueAsset:
 		result := tx.GetMergedAssetIDValueFromOutputs()
 		if err != nil {
@@ -336,16 +332,12 @@ func (tx *Transaction) GetProgramHashes() ([]Uint160, error) {
 		hashs = append(hashs, tx.Payload.(*payload.Withdraw).ProgramHash)
 	case BookKeeper:
 		issuer := tx.Payload.(*payload.BookKeeper).Issuer
-		signatureRedeemScript, err := contract.CreateSignatureRedeemScript(issuer)
+		hash, err := contract.CreateRedeemHash(issuer)
 		if err != nil {
-			return nil, NewDetailErr(err, ErrNoCode, "[Transaction - BookKeeper], GetProgramHashes CreateSignatureRedeemScript failed.")
+			return nil, fmt.Errorf("%v\n%s", err, "[Transaction] GetProgramHashes bookkeeper hash generated failed")
 		}
 
-		astHash, err := ToCodeHash(signatureRedeemScript)
-		if err != nil {
-			return nil, NewDetailErr(err, ErrNoCode, "[Transaction - BookKeeper], GetProgramHashes ToCodeHash failed.")
-		}
-		hashs = append(hashs, astHash)
+		hashs = append(hashs, hash)
 	case RegisterName:
 		registrant := tx.Payload.(*payload.RegisterName).Registrant
 		signatureRedeemScript, err := contract.CreateSignatureRedeemScriptWithEncodedPublicKey(registrant)
@@ -353,11 +345,11 @@ func (tx *Transaction) GetProgramHashes() ([]Uint160, error) {
 			return nil, NewDetailErr(err, ErrNoCode, "[Transaction], GetProgramHashes CreateSignatureRedeemScript failed.")
 		}
 
-		astHash, err := ToCodeHash(signatureRedeemScript)
+		hash, err := ToCodeHash(signatureRedeemScript)
 		if err != nil {
 			return nil, NewDetailErr(err, ErrNoCode, "[Transaction], GetProgramHashes ToCodeHash failed.")
 		}
-		hashs = append(hashs, astHash)
+		hashs = append(hashs, hash)
 	case DeleteName:
 		registrant := tx.Payload.(*payload.DeleteName).Registrant
 		signatureRedeemScript, err := contract.CreateSignatureRedeemScriptWithEncodedPublicKey(registrant)
@@ -365,11 +357,11 @@ func (tx *Transaction) GetProgramHashes() ([]Uint160, error) {
 			return nil, NewDetailErr(err, ErrNoCode, "[Transaction], GetProgramHashes CreateSignatureRedeemScript failed.")
 		}
 
-		astHash, err := ToCodeHash(signatureRedeemScript)
+		hash, err := ToCodeHash(signatureRedeemScript)
 		if err != nil {
 			return nil, NewDetailErr(err, ErrNoCode, "[Transaction], GetProgramHashes ToCodeHash failed.")
 		}
-		hashs = append(hashs, astHash)
+		hashs = append(hashs, hash)
 	default:
 	}
 	//remove dupilicated hashes

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -73,6 +73,7 @@ type Configuration struct {
 	Hostname             string   `json:"Hostname"`
 	Transport            string   `json:"Transport"`
 	NAT                  bool     `json:"NAT"`
+	BeneficiaryAddr	     string   `json:"BeneficiaryAddr"`
 }
 
 func Init() error {

--- a/vault/account.go
+++ b/vault/account.go
@@ -7,7 +7,6 @@ import (
 	. "github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/core/contract"
 	"github.com/nknorg/nkn/crypto"
-	. "github.com/nknorg/nkn/errors"
 )
 
 type Account struct {
@@ -18,18 +17,15 @@ type Account struct {
 
 func NewAccount() (*Account, error) {
 	priKey, pubKey, _ := crypto.GenKeyPair()
-	signatureRedeemScript, err := contract.CreateSignatureRedeemScript(&pubKey)
+
+	redeemHash, err := contract.CreateRedeemHash(&pubKey)
 	if err != nil {
-		return nil, NewDetailErr(err, ErrNoCode, "CreateSignatureRedeemScript failed")
-	}
-	programHash, err := ToCodeHash(signatureRedeemScript)
-	if err != nil {
-		return nil, NewDetailErr(err, ErrNoCode, "ToCodeHash failed")
+		return nil, fmt.Errorf("%v\n%s", err, "New account redeemhash generated failed")
 	}
 	return &Account{
 		PrivateKey:  priKey,
 		PublicKey:   &pubKey,
-		ProgramHash: programHash,
+		ProgramHash: redeemHash,
 	}, nil
 }
 
@@ -39,7 +35,7 @@ func NewAccountWithPrivatekey(privateKey []byte) (*Account, error) {
 		return nil, errors.New("invalid private key length")
 	}
 	pubKey := crypto.NewPubKey(privateKey)
-	RedeemHash, err := contract.CreateRedeemHash(pubKey)
+	redeemHash, err := contract.CreateRedeemHash(pubKey)
 	if err != nil {
 		return nil, fmt.Errorf("%v\n%s", err, "New account redeemhash generated failed")
 	}
@@ -47,7 +43,7 @@ func NewAccountWithPrivatekey(privateKey []byte) (*Account, error) {
 	return &Account{
 		PrivateKey:  privateKey,
 		PublicKey:   pubKey,
-		ProgramHash: RedeemHash,
+		ProgramHash: redeemHash,
 	}, nil
 }
 

--- a/vault/account.go
+++ b/vault/account.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"errors"
+	"fmt"
 
 	. "github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/core/contract"
@@ -38,18 +39,15 @@ func NewAccountWithPrivatekey(privateKey []byte) (*Account, error) {
 		return nil, errors.New("invalid private key length")
 	}
 	pubKey := crypto.NewPubKey(privateKey)
-	signatureRedeemScript, err := contract.CreateSignatureRedeemScript(pubKey)
+	RedeemHash, err := contract.CreateRedeemHash(pubKey)
 	if err != nil {
-		return nil, NewDetailErr(err, ErrNoCode, "CreateSignatureRedeemScript failed")
+		return nil, fmt.Errorf("%v\n%s", err, "New account redeemhash generated failed")
 	}
-	programHash, err := ToCodeHash(signatureRedeemScript)
-	if err != nil {
-		return nil, NewDetailErr(err, ErrNoCode, "ToCodeHash failed")
-	}
+
 	return &Account{
 		PrivateKey:  privateKey,
 		PublicKey:   pubKey,
-		ProgramHash: programHash,
+		ProgramHash: RedeemHash,
 	}, nil
 }
 

--- a/vault/wallet.go
+++ b/vault/wallet.go
@@ -208,16 +208,12 @@ func (w *WalletImpl) GetDefaultAccount() (*Account, error) {
 }
 
 func (w *WalletImpl) GetAccount(pubKey *crypto.PubKey) (*Account, error) {
-	signatureRedeemScript, err := contract.CreateSignatureRedeemScript(pubKey)
+	redeemHash, err := contract.CreateRedeemHash(pubKey)
 	if err != nil {
-		return nil, err
-	}
-	programHash, err := ToCodeHash(signatureRedeemScript)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%v\n%s", err, "[Account] GetAccount redeemhash generated failed")
 	}
 
-	if programHash != w.account.ProgramHash {
+	if redeemHash != w.account.ProgramHash {
 		return nil, errors.New("invalid account")
 	}
 


### PR DESCRIPTION
In some cases we want the reward token  of mining to be sent
directly to another wallet instead of the mining node itself.
This patch allows the miner to configure an extra address
"BeneficiaryAddr" in the config.json to receive the reward of
the mining.

Change some mining-related variable names to make the program
easier to read.

Signed-off-by: Yanbo Li <dreamfly281@gmail.com>

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
