### PR TITLE
Refactor getchordringinfo API for adapted to nnet's Chord overlay

### DIFF
--- a/api/common/interfaces.go
+++ b/api/common/interfaces.go
@@ -115,11 +115,11 @@ func getBlockCount(s Serverer, params map[string]interface{}) map[string]interfa
 // params: []
 // return: {"result":<result>, "error":<errcode>}
 func getChordRingInfo(s Serverer, params map[string]interface{}) map[string]interface{} {
-	// node, err := s.GetNetNode()
-	// if err != nil {
-	// 	return respPacking(nil, INTERNAL_ERROR)
-	// }
-	return respPacking(nil, SUCCESS)
+	node, err := s.GetNetNode()
+	if err != nil {
+		return respPacking(nil, INTERNAL_ERROR)
+	}
+	return respPacking(node.DumpChordInfo(), SUCCESS)
 }
 
 // getLatestBlockHeight gets the latest block height

--- a/glide.lock
+++ b/glide.lock
@@ -55,7 +55,7 @@ imports:
 - name: github.com/nknorg/gopass
   version: 9ddc09fe41c891b7987acd1bf75f9067a56c17f5
 - name: github.com/nknorg/nnet
-  version: b55f50756ff0789d1773c2918180a72c4f334d65
+  version: ae33039c242f1d2a4e13cd690d98b7a8f4f0cfa6
   subpackages:
   - cache
   - common

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nknorg/nkn/crypto"
 	. "github.com/nknorg/nkn/errors"
 	"github.com/nknorg/nkn/events"
+	"github.com/nknorg/nkn/protobuf"
 	"github.com/nknorg/nkn/vault"
 )
 
@@ -94,6 +95,24 @@ type Noder interface {
 	GetWsAddr() string
 	FindWsAddr([]byte) (string, error)
 	FindSuccessorAddrs([]byte, int) ([]string, error)
+	DumpChordInfo() *ChordInfo
+	GetSuccessors() []*ChordNodeInfo
+	GetPredecessors() []*ChordNodeInfo
+	GetFingerTab() map[int][]*ChordNodeInfo
+}
+
+type ChordInfo struct {
+	Node         ChordNodeInfo
+	Successors   []*ChordNodeInfo
+	Predecessors []*ChordNodeInfo
+	FingerTable  map[int][]*ChordNodeInfo
+}
+
+type ChordNodeInfo struct {
+	ID         string
+	Addr       string
+	IsOutbound bool
+	protobuf.NodeData
 }
 
 type NodeAddr struct {


### PR DESCRIPTION
Signed-off-by: gdmmx <gdmmx@163.com>

### Proposed changes in this pull request
The overlay network was replaced by net since v0.5.x-alpha. Previous getchordringinfo API is not suitable of v0.5.x
Refactor getchordringinfo API for adapted to nnet's Chord overlay

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.