### PR TITLE
Fixed config.LogLevel ineffective issue

### DIFF
--- a/nknd.go
+++ b/nknd.go
@@ -121,6 +121,7 @@ func nknMain(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	log.Log.SetDebugLevel(config.Parameters.LogLevel) // Update LogLevel after config.json loaded
 
 	// Get local account
 	wallet := vault.GetWallet()


### PR DESCRIPTION
Signed-off-by: gdmmx <gdmmx@163.com>

### Proposed changes in this pull request
nkn/util/log Init() early than config.Init(), it due to config.LogLevel is ineffective.
Update log.LogLevel after config.json was loaded in order to make it effective.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.