### PR TITLE
Add connect direction with neighbors in getneighbor API

### DIFF
--- a/net/node/neighbor.go
+++ b/net/node/neighbor.go
@@ -54,6 +54,7 @@ func (nm *nbrNodes) GetNeighborAddrs() ([]protocol.NodeAddr, uint) {
 		addrs = append(addrs, protocol.NodeAddr{
 			IpAddr:  ip,
 			IpStr:   n.GetAddr(),
+			InOut:   n.GetConnDirection(),
 			Time:    n.GetTime(),
 			Port:    n.GetPort(),
 			ID:      n.GetID(),

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -416,6 +416,16 @@ func (node *node) GetAddrStr() string {
 	return node.nnetNode.Addr
 }
 
+func (node *node) GetConnDirection() string {
+	if node.nnet != nil {
+		return "LocalNode"
+	}
+	if node.nnetNode.IsOutbound { // is RemoteNode
+		return "Outbound"
+	}
+	return "Inbound"
+}
+
 func (node *node) GetTime() int64 {
 	t := time.Now()
 	return t.UnixNano()

--- a/net/protocol/protocol.go
+++ b/net/protocol/protocol.go
@@ -68,6 +68,7 @@ type Noder interface {
 	GetTime() int64
 	GetEvent(eventName string) *events.Event
 	GetNeighborAddrs() ([]NodeAddr, uint)
+	GetConnDirection() string
 	GetTransaction(hash Uint256) *transaction.Transaction
 	IncRxTxnCnt()
 	GetTxnCnt() uint64
@@ -120,6 +121,7 @@ type NodeAddr struct {
 	Time    int64
 	IpAddr  [16]byte
 	IpStr   string
+	InOut   string
 	Port    uint16
 	ID      uint64
 	NKNaddr string


### PR DESCRIPTION
Signed-off-by: gdmmx <gdmmx@163.com>

### Proposed changes in this pull request
There is no neighbors connection direction info in getneighbor API. It is not friendly for diagnoses the node's connectivity who behind NAT.
Add connection direction info in order to help for diagnoses.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
