### PR TITLE
Solid passwd replace with random passwd during init wallet automatic

### DIFF
--- a/test/create_testbed.sh
+++ b/test/create_testbed.sh
@@ -12,7 +12,7 @@ function Usage () {
     printf "${RED}Example${END}: ${BLUE}%s${END} ${GREEN}10${END} ${YELLOW}test_env${END}\n" $1
 }
 
-[ -n "$1" ] && [ "$1" -gt 1 ] || ! Usage $0 || exit $EINVAL
+[ -n "$1" ] && [ "$1" -ge 1 ] || ! Usage $0 || exit $EINVAL
 NodeNum=$1
 
 TARGET_DIR=${2}
@@ -27,14 +27,17 @@ mkdir -p ${TARGET_DIR}
 seq 1 ${NodeNum} | xargs printf "%04d\n" | while read i
 do
     mkdir -p ${TARGET_DIR}/node_${i}
-    cp -a nknd nknc config.json ${TARGET_DIR}/node_${i}/  || exit $?
+    cp -a nknd nknc ${TARGET_DIR}/node_${i}/  || exit $?
+    cp -a config.testnet.json ${TARGET_DIR}/node_${i}/config.json  || exit $?
 
     ### init wallet.dat
     rm -f wallet.dat
+    RANDOM_PASSWD=$(head -c 256 /dev/urandom |base64 |head -c 16)
     ./nknc wallet -c <<EOF
-testbed
-testbed
+${RANDOM_PASSWD}
+${RANDOM_PASSWD}
 EOF
     [ $? -eq 0 ] || exit $?
+    echo ${RANDOM_PASSWD} > ${TARGET_DIR}/node_${i}/wallet.pswd
     mv wallet.dat ${TARGET_DIR}/node_${i}/ || exit $?
 done

--- a/test/launch_node.sh
+++ b/test/launch_node.sh
@@ -20,11 +20,10 @@ EOF
 }
 
 function start () {
-    ./nknd "$@" <<EOF
-testbed
-EOF
+    ./nknd "$@" -p $(cat ./wallet.pswd)
 }
 
+ulimit -n 10240
 ulimit -c unlimited
 export GOTRACEBACK=crash
 


### PR DESCRIPTION
Signed-off-by: gdmmx <gdmmx@163.com>

### Proposed changes in this pull request
Currently, the automation test script used solid passwd to create wallet.dat. All of the test nodes wallet with same password. It is a vulnerability for testnet automatic node.
Used random password to create wallet for more safety.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
