### PR TITLE
Auto-update to latest tag instead of latest commit

### DIFF
--- a/test/ci/node_join.sh
+++ b/test/ci/node_join.sh
@@ -9,7 +9,7 @@ NKN_HOME=$(realpath $CI_DIR/../..)
 BIN_DIR="testbed/node_0001"
 
 ### Setup seed list by cmdline or hard code a default
-[ -z "$1" ] && DEFAULT_SEED="35.201.21.23:30003" || DEFAULT_SEED=$1
+[ -z "$1" ] && DEFAULT_SEED="" || DEFAULT_SEED=$1
 
 ###
 # func: init bin dir and adjust config.json for adapted to run on cloud
@@ -19,7 +19,7 @@ BIN_DIR="testbed/node_0001"
 function init_bin () {
     ./test/create_testbed.sh 2 $(dirname ${1})
     sed -i '/127.0.0.1/d' ./${1}/config.json
-    sed -i '/SeedList/a"'$2'"' ./${1}/config.json
+    [ -n "$2" ] && sed -i '/SeedList/a"'$2'",' ./${1}/config.json
 }
 
 ### init bin dir if it not exist
@@ -27,8 +27,10 @@ cd $NKN_HOME
 [ -d ./${BIN_DIR} ] || init_bin ${BIN_DIR} ${DEFAULT_SEED}
 
 ### Obtain latest src code and build binary
-git pull
+git fetch
+LATEST_TAG=$(git for-each-ref --sort=-taggerdate --count=1 --format "%(refname:short)" refs/tags)
+git checkout ${LATEST_TAG}
 make
 cp -a nkn[cd] ./${BIN_DIR}/
 
-./test/launch_node.sh ./${BIN_DIR}/ --no-check-port
+./test/launch_node.sh ./${BIN_DIR}/ --no-nat


### PR DESCRIPTION
Signed-off-by: gdmmx <gdmmx@163.com>

### Proposed changes in this pull request
Auto-update to latest tag instead of latest commit

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.