### PR TITLE
Urgent workaround for syncblock stuck bug

### DIFF
--- a/api/common/interfaces.go
+++ b/api/common/interfaces.go
@@ -343,7 +343,7 @@ func getNodeState(s Serverer, params map[string]interface{}) map[string]interfac
 		WsPort:    node.GetWsPort(),
 		ID:        node.GetID(),
 		Version:   node.Version(),
-		Height:    node.GetHeight(),
+		Height:    ledger.DefaultLedger.Store.GetHeight(),
 		PubKey:    hex.EncodeToString(key),
 		TxnCnt:    node.GetTxnCnt(),
 		RxTxnCnt:  node.GetRxTxnCnt(),

--- a/net/node/node.go
+++ b/net/node/node.go
@@ -363,7 +363,7 @@ func (node *node) GetTxnPool() *pool.TxnPool {
 }
 
 func (node *node) GetHeight() uint32 {
-	return ledger.DefaultLedger.Store.GetHeight()
+	return node.height
 }
 
 func (node *node) SetHeight(height uint32) {


### PR DESCRIPTION
Signed-off-by: gdmmx <gdmmx@163.com>

### Proposed changes in this pull request
Syncblock routine will stuck by unknown reason after node.GetHeight() gain correct height from ledger. This bug affect part of nodes on testnet already.
Workaround fix it for urgency. Will track out root cause in future.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [x] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
