### PR TITLE
Add timestamp check when receiving block flooding msg

### DIFF
--- a/consensus/ising/proposerservice.go
+++ b/consensus/ising/proposerservice.go
@@ -301,8 +301,8 @@ func (ps *ProposerService) ProduceNewBlock() {
 	info := ps.proposerCache.Get(votingHeight + 1)
 	if info == nil {
 		info = &ProposerInfo{
-			winnerHash:	EmptyUint256,
-			winnerType:	ledger.BlockSigner,
+			winnerHash: EmptyUint256,
+			winnerType: ledger.BlockSigner,
 		}
 	}
 	// build new block to be proposed
@@ -690,11 +690,19 @@ func (ps *ProposerService) HandleBlockFloodingMsg(bfMsg *BlockFlooding, sender u
 				log.Error("header verification error when voting in sync mode", err)
 				return
 			}
+
+			err = ledger.TimestampCheck(block.Header.Timestamp)
+			if err != nil {
+				log.Error("Proposal fails to pass timestamp check", err)
+				return
+			}
+
 			err = ledger.TransactionCheck(block)
 			if err != nil {
 				log.Error("transaction verification error when voting in sync mode", err)
 				return
 			}
+
 			log.Infof("send vote to block %s while syncing", BytesToHexString(blockHash.ToArrayReverse()))
 			proposalMsg := NewProposal(&blockHash, votingHeight, voting.BlockVote)
 			nodes := ps.GetReceiverNode(nil)

--- a/core/ledger/validator.go
+++ b/core/ledger/validator.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	GenesisBlockProposedHeight = 4
+	TimestampTolerance         = 60 * time.Second
 )
 
 type VBlock struct {
@@ -182,5 +183,15 @@ func HeaderCheck(header *Header, receiveTime int64) error {
 		return err
 	}
 
+	return nil
+}
+
+func TimestampCheck(timestamp int64) error {
+	now := time.Now()
+	earliest := now.Add(-TimestampTolerance).Unix()
+	latest := now.Add(TimestampTolerance).Unix()
+	if timestamp < earliest || timestamp > latest {
+		return errors.New("Invalid timestamp")
+	}
 	return nil
 }

--- a/core/ledger/validator.go
+++ b/core/ledger/validator.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	GenesisBlockProposedHeight = 4
-	TimestampTolerance         = 60 * time.Second
+	TimestampTolerance         = 40 * time.Second
 )
 
 type VBlock struct {


### PR DESCRIPTION
Add timestamp check when receiving block flooding msg

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [x] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.