### PR TITLE
add buckets to subscriptions

### DIFF
--- a/api/common/common.go
+++ b/api/common/common.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"github.com/nknorg/nkn/errors"
 	"github.com/nknorg/nkn/net/protocol"
 	"github.com/nknorg/nkn/vault"
 )
@@ -14,6 +15,15 @@ func respPacking(result interface{}, errcode ErrCode) map[string]interface{} {
 	resp := map[string]interface{}{
 		"result": result,
 		"error":  errcode,
+	}
+	return resp
+}
+
+func respPackingDetails(result interface{}, errcode ErrCode, details errors.ErrCode) map[string]interface{} {
+	resp := map[string]interface{}{
+		"result":  result,
+		"error":   errcode,
+		"details": details,
 	}
 	return resp
 }

--- a/api/common/helper.go
+++ b/api/common/helper.go
@@ -303,7 +303,7 @@ func MakeDeleteNameTransaction(wallet vault.Wallet) (*transaction.Transaction, e
 	return txn, nil
 }
 
-func MakeSubscribeTransaction(wallet vault.Wallet, identifier string, topic string, duration uint32) (*transaction.Transaction, error) {
+func MakeSubscribeTransaction(wallet vault.Wallet, identifier string, topic string, bucket uint32, duration uint32) (*transaction.Transaction, error) {
 	account, err := wallet.GetDefaultAccount()
 	if err != nil {
 		return nil, err
@@ -312,7 +312,7 @@ func MakeSubscribeTransaction(wallet vault.Wallet, identifier string, topic stri
 	if err != nil {
 		return nil, err
 	}
-	txn, err := transaction.NewSubscribeTransaction(subscriber, identifier, topic, duration)
+	txn, err := transaction.NewSubscribeTransaction(subscriber, identifier, topic, bucket, duration)
 	if err != nil {
 		return nil, err
 	}

--- a/api/common/interfaces.go
+++ b/api/common/interfaces.go
@@ -1132,7 +1132,7 @@ func getAddressByName(s Serverer, params map[string]interface{}) map[string]inte
 }
 
 // getSubscribers get subscribers by topic
-// params: ["topic":<topic>]
+// params: ["topic":<topic>, "bucket":<bucket>]
 // return: {"result":<result>, "error":<errcode>}
 func getSubscribers(s Serverer, params map[string]interface{}) map[string]interface{} {
 	if len(params) < 1 {
@@ -1144,7 +1144,12 @@ func getSubscribers(s Serverer, params map[string]interface{}) map[string]interf
 		return respPacking(nil, INVALID_PARAMS)
 	}
 
-	subscribers := ledger.DefaultLedger.Store.GetSubscribers(topic)
+	bucket, ok := params["bucket"].(float64)
+	if !ok {
+		return respPacking(nil, INVALID_PARAMS)
+	}
+
+	subscribers := ledger.DefaultLedger.Store.GetSubscribers(topic, uint32(bucket))
 	return respPacking(subscribers, SUCCESS)
 }
 

--- a/api/common/interfaces.go
+++ b/api/common/interfaces.go
@@ -1153,6 +1153,23 @@ func getSubscribers(s Serverer, params map[string]interface{}) map[string]interf
 	return respPacking(subscribers, SUCCESS)
 }
 
+// getFreeTopicBucket get free topic bucket
+// params: ["topic":<topic>]
+// return: {"result":<result>, "error":<errcode>}
+func getFreeTopicBucket(s Serverer, params map[string]interface{}) map[string]interface{} {
+	if len(params) < 1 {
+		return respPacking(nil, INVALID_PARAMS)
+	}
+
+	topic, ok := params["topic"].(string)
+	if !ok {
+		return respPacking(nil, INVALID_PARAMS)
+	}
+
+	freeBucket := ledger.DefaultLedger.Store.GetFreeTopicBucket(topic)
+	return respPacking(freeBucket, SUCCESS)
+}
+
 // getTopicBucketsCount get topic buckets count
 // params: ["topic":<topic>]
 // return: {"result":<result>, "error":<errcode>}
@@ -1269,6 +1286,7 @@ var InitialAPIHandlers = map[string]APIHandler{
 	"getunspends":          {Handler: getUnspends},
 	"getaddressbyname":     {Handler: getAddressByName, AccessCtrl: BIT_JSONRPC},
 	"getsubscribers":       {Handler: getSubscribers, AccessCtrl: BIT_JSONRPC},
+	"getfreetopicbucket":   {Handler: getFreeTopicBucket, AccessCtrl: BIT_JSONRPC},
 	"gettopicbucketscount": {Handler: getTopicBucketsCount, AccessCtrl: BIT_JSONRPC},
 	"findsuccessoraddr":    {Handler: findSuccessorAddr, AccessCtrl: BIT_JSONRPC},
 	"findsuccessoraddrs":   {Handler: findSuccessorAddrs, AccessCtrl: BIT_JSONRPC},

--- a/api/common/interfaces.go
+++ b/api/common/interfaces.go
@@ -279,7 +279,7 @@ func getTransaction(s Serverer, params map[string]interface{}) map[string]interf
 
 // sendRawTransaction  sends raw transaction to the block chain
 // params: ["tx":<transaction>]
-// return: {"result":<result>, "error":<errcode>}
+// return: {"result":<result>, "error":<errcode>, "details":<details>}
 func sendRawTransaction(s Serverer, params map[string]interface{}) map[string]interface{} {
 	if len(params) < 1 {
 		return respPacking(nil, INVALID_PARAMS)
@@ -303,7 +303,7 @@ func sendRawTransaction(s Serverer, params map[string]interface{}) map[string]in
 
 		hash = txn.Hash()
 		if errCode := VerifyAndSendTx(node, &txn); errCode != errors.ErrNoError {
-			return respPacking(nil, INVALID_TRANSACTION)
+			return respPackingDetails(nil, INVALID_TRANSACTION, errCode)
 		}
 	} else {
 		return respPacking(nil, INVALID_PARAMS)
@@ -1153,10 +1153,10 @@ func getSubscribers(s Serverer, params map[string]interface{}) map[string]interf
 	return respPacking(subscribers, SUCCESS)
 }
 
-// getFreeTopicBucket get free topic bucket
+// getFirstAvailableTopicBucket get free topic bucket
 // params: ["topic":<topic>]
 // return: {"result":<result>, "error":<errcode>}
-func getFreeTopicBucket(s Serverer, params map[string]interface{}) map[string]interface{} {
+func getFirstAvailableTopicBucket(s Serverer, params map[string]interface{}) map[string]interface{} {
 	if len(params) < 1 {
 		return respPacking(nil, INVALID_PARAMS)
 	}
@@ -1166,8 +1166,8 @@ func getFreeTopicBucket(s Serverer, params map[string]interface{}) map[string]in
 		return respPacking(nil, INVALID_PARAMS)
 	}
 
-	freeBucket := ledger.DefaultLedger.Store.GetFreeTopicBucket(topic)
-	return respPacking(freeBucket, SUCCESS)
+	bucket := ledger.DefaultLedger.Store.GetFirstAvailableTopicBucket(topic)
+	return respPacking(bucket, SUCCESS)
 }
 
 // getTopicBucketsCount get topic buckets count
@@ -1183,8 +1183,8 @@ func getTopicBucketsCount(s Serverer, params map[string]interface{}) map[string]
 		return respPacking(nil, INVALID_PARAMS)
 	}
 
-	lastBucket := ledger.DefaultLedger.Store.GetTopicBucketsCount(topic)
-	return respPacking(lastBucket, SUCCESS)
+	count := ledger.DefaultLedger.Store.GetTopicBucketsCount(topic)
+	return respPacking(count, SUCCESS)
 }
 
 // findSuccessorAddrs find the successors of a key
@@ -1252,42 +1252,42 @@ func findSuccessorAddr(s Serverer, params map[string]interface{}) map[string]int
 }
 
 var InitialAPIHandlers = map[string]APIHandler{
-	"getlatestblockhash":   {Handler: getLatestBlockHash, AccessCtrl: BIT_JSONRPC},
-	"getblock":             {Handler: getBlock, AccessCtrl: BIT_JSONRPC | BIT_WEBSOCKET},
-	"getblockcount":        {Handler: getBlockCount, AccessCtrl: BIT_JSONRPC},
-	"getlatestblockheight": {Handler: getLatestBlockHeight, AccessCtrl: BIT_JSONRPC | BIT_WEBSOCKET},
-	"getblocktxsbyheight":  {Handler: getBlockTxsByHeight, AccessCtrl: BIT_JSONRPC},
-	"getconnectioncount":   {Handler: getConnectionCount, AccessCtrl: BIT_JSONRPC | BIT_WEBSOCKET},
-	"getrawmempool":        {Handler: getRawMemPool, AccessCtrl: BIT_JSONRPC},
-	"gettransaction":       {Handler: getTransaction, AccessCtrl: BIT_JSONRPC | BIT_WEBSOCKET},
-	"sendrawtransaction":   {Handler: sendRawTransaction, AccessCtrl: BIT_JSONRPC | BIT_WEBSOCKET},
-	"getwsaddr":            {Handler: getWsAddr, AccessCtrl: BIT_JSONRPC},
-	"gethttpproxyaddr":     {Handler: getHttpProxyAddr, AccessCtrl: BIT_JSONRPC},
-	"getversion":           {Handler: getVersion, AccessCtrl: BIT_JSONRPC},
-	"getneighbor":          {Handler: getNeighbor, AccessCtrl: BIT_JSONRPC},
-	"getnodestate":         {Handler: getNodeState, AccessCtrl: BIT_JSONRPC},
-	"getchordringinfo":     {Handler: getChordRingInfo, AccessCtrl: BIT_JSONRPC},
-	"getunspendoutput":     {Handler: getUnspendOutput, AccessCtrl: BIT_JSONRPC},
-	"getbalance":           {Handler: getBalance},
-	"setdebuginfo":         {Handler: setDebugInfo},
-	"registasset":          {Handler: registAsset},
-	"issueasset":           {Handler: issueAsset},
-	"sendtoaddress":        {Handler: sendToAddress},
-	"prepaidasset":         {Handler: prepaidAsset},
-	"registername":         {Handler: registerName},
-	"deletename":           {Handler: deleteName},
-	"withdrawasset":        {Handler: withdrawAsset},
-	"commitpor":            {Handler: commitPor},
-	"sigchaintest":         {Handler: sigchaintest},
-	"gettotalissued":       {Handler: getTotalIssued},
-	"getassetbyhash":       {Handler: getAssetByHash},
-	"getbalancebyaddr":     {Handler: getBalanceByAddr, AccessCtrl: BIT_JSONRPC},
-	"getbalancebyasset":    {Handler: getBalanceByAsset},
-	"getunspends":          {Handler: getUnspends},
-	"getaddressbyname":     {Handler: getAddressByName, AccessCtrl: BIT_JSONRPC},
-	"getsubscribers":       {Handler: getSubscribers, AccessCtrl: BIT_JSONRPC},
-	"getfreetopicbucket":   {Handler: getFreeTopicBucket, AccessCtrl: BIT_JSONRPC},
-	"gettopicbucketscount": {Handler: getTopicBucketsCount, AccessCtrl: BIT_JSONRPC},
-	"findsuccessoraddr":    {Handler: findSuccessorAddr, AccessCtrl: BIT_JSONRPC},
-	"findsuccessoraddrs":   {Handler: findSuccessorAddrs, AccessCtrl: BIT_JSONRPC},
+	"getlatestblockhash":           {Handler: getLatestBlockHash, AccessCtrl: BIT_JSONRPC},
+	"getblock":                     {Handler: getBlock, AccessCtrl: BIT_JSONRPC | BIT_WEBSOCKET},
+	"getblockcount":                {Handler: getBlockCount, AccessCtrl: BIT_JSONRPC},
+	"getlatestblockheight":         {Handler: getLatestBlockHeight, AccessCtrl: BIT_JSONRPC | BIT_WEBSOCKET},
+	"getblocktxsbyheight":          {Handler: getBlockTxsByHeight, AccessCtrl: BIT_JSONRPC},
+	"getconnectioncount":           {Handler: getConnectionCount, AccessCtrl: BIT_JSONRPC | BIT_WEBSOCKET},
+	"getrawmempool":                {Handler: getRawMemPool, AccessCtrl: BIT_JSONRPC},
+	"gettransaction":               {Handler: getTransaction, AccessCtrl: BIT_JSONRPC | BIT_WEBSOCKET},
+	"sendrawtransaction":           {Handler: sendRawTransaction, AccessCtrl: BIT_JSONRPC | BIT_WEBSOCKET},
+	"getwsaddr":                    {Handler: getWsAddr, AccessCtrl: BIT_JSONRPC},
+	"gethttpproxyaddr":             {Handler: getHttpProxyAddr, AccessCtrl: BIT_JSONRPC},
+	"getversion":                   {Handler: getVersion, AccessCtrl: BIT_JSONRPC},
+	"getneighbor":                  {Handler: getNeighbor, AccessCtrl: BIT_JSONRPC},
+	"getnodestate":                 {Handler: getNodeState, AccessCtrl: BIT_JSONRPC},
+	"getchordringinfo":             {Handler: getChordRingInfo, AccessCtrl: BIT_JSONRPC},
+	"getunspendoutput":             {Handler: getUnspendOutput, AccessCtrl: BIT_JSONRPC},
+	"getbalance":                   {Handler: getBalance},
+	"setdebuginfo":                 {Handler: setDebugInfo},
+	"registasset":                  {Handler: registAsset},
+	"issueasset":                   {Handler: issueAsset},
+	"sendtoaddress":                {Handler: sendToAddress},
+	"prepaidasset":                 {Handler: prepaidAsset},
+	"registername":                 {Handler: registerName},
+	"deletename":                   {Handler: deleteName},
+	"withdrawasset":                {Handler: withdrawAsset},
+	"commitpor":                    {Handler: commitPor},
+	"sigchaintest":                 {Handler: sigchaintest},
+	"gettotalissued":               {Handler: getTotalIssued},
+	"getassetbyhash":               {Handler: getAssetByHash},
+	"getbalancebyaddr":             {Handler: getBalanceByAddr, AccessCtrl: BIT_JSONRPC},
+	"getbalancebyasset":            {Handler: getBalanceByAsset},
+	"getunspends":                  {Handler: getUnspends},
+	"getaddressbyname":             {Handler: getAddressByName, AccessCtrl: BIT_JSONRPC},
+	"getsubscribers":               {Handler: getSubscribers, AccessCtrl: BIT_JSONRPC},
+	"getfirstavailabletopicbucket": {Handler: getFirstAvailableTopicBucket, AccessCtrl: BIT_JSONRPC},
+	"gettopicbucketscount":         {Handler: getTopicBucketsCount, AccessCtrl: BIT_JSONRPC},
+	"findsuccessoraddr":            {Handler: findSuccessorAddr, AccessCtrl: BIT_JSONRPC},
+	"findsuccessoraddrs":           {Handler: findSuccessorAddrs, AccessCtrl: BIT_JSONRPC},
 }

--- a/api/common/interfaces.go
+++ b/api/common/interfaces.go
@@ -1153,6 +1153,23 @@ func getSubscribers(s Serverer, params map[string]interface{}) map[string]interf
 	return respPacking(subscribers, SUCCESS)
 }
 
+// getTopicBucketsCount get topic buckets count
+// params: ["topic":<topic>]
+// return: {"result":<result>, "error":<errcode>}
+func getTopicBucketsCount(s Serverer, params map[string]interface{}) map[string]interface{} {
+	if len(params) < 1 {
+		return respPacking(nil, INVALID_PARAMS)
+	}
+
+	topic, ok := params["topic"].(string)
+	if !ok {
+		return respPacking(nil, INVALID_PARAMS)
+	}
+
+	lastBucket := ledger.DefaultLedger.Store.GetTopicBucketsCount(topic)
+	return respPacking(lastBucket, SUCCESS)
+}
+
 // findSuccessorAddrs find the successors of a key
 // params: ["address":<address>]
 // return: {"result":<result>, "error":<errcode>}
@@ -1252,6 +1269,7 @@ var InitialAPIHandlers = map[string]APIHandler{
 	"getunspends":          {Handler: getUnspends},
 	"getaddressbyname":     {Handler: getAddressByName, AccessCtrl: BIT_JSONRPC},
 	"getsubscribers":       {Handler: getSubscribers, AccessCtrl: BIT_JSONRPC},
+	"gettopicbucketscount": {Handler: getTopicBucketsCount, AccessCtrl: BIT_JSONRPC},
 	"findsuccessoraddr":    {Handler: findSuccessorAddr, AccessCtrl: BIT_JSONRPC},
 	"findsuccessoraddrs":   {Handler: findSuccessorAddrs, AccessCtrl: BIT_JSONRPC},
 }

--- a/core/ledger/ledgerStore.go
+++ b/core/ledger/ledgerStore.go
@@ -31,9 +31,9 @@ type ILedgerStore interface {
 	GetName(registrant []byte) (*string, error)
 	GetRegistrant(name string) ([]byte, error)
 
-	IsSubscribed(subscriber []byte, identifier string, topic string) (bool, error)
-	GetSubscribers(topic string) []string
-	GetSubscribersCount(topic string) int
+	IsSubscribed(subscriber []byte, identifier string, topic string, bucket uint32) (bool, error)
+	GetSubscribers(topic string, bucket uint32) []string
+	GetSubscribersCount(topic string, bucket uint32) int
 
 	GetContract(codeHash Uint160) ([]byte, error)
 	GetStorage(key []byte) ([]byte, error)

--- a/core/ledger/ledgerStore.go
+++ b/core/ledger/ledgerStore.go
@@ -34,7 +34,7 @@ type ILedgerStore interface {
 	IsSubscribed(subscriber []byte, identifier string, topic string, bucket uint32) (bool, error)
 	GetSubscribers(topic string, bucket uint32) []string
 	GetSubscribersCount(topic string, bucket uint32) int
-	GetFreeTopicBucket(topic string) int
+	GetFirstAvailableTopicBucket(topic string) int
 	GetTopicBucketsCount(topic string) uint32
 
 	GetContract(codeHash Uint160) ([]byte, error)

--- a/core/ledger/ledgerStore.go
+++ b/core/ledger/ledgerStore.go
@@ -34,6 +34,7 @@ type ILedgerStore interface {
 	IsSubscribed(subscriber []byte, identifier string, topic string, bucket uint32) (bool, error)
 	GetSubscribers(topic string, bucket uint32) []string
 	GetSubscribersCount(topic string, bucket uint32) int
+	GetTopicBucketsCount(topic string) uint32
 
 	GetContract(codeHash Uint160) ([]byte, error)
 	GetStorage(key []byte) ([]byte, error)

--- a/core/ledger/ledgerStore.go
+++ b/core/ledger/ledgerStore.go
@@ -34,6 +34,7 @@ type ILedgerStore interface {
 	IsSubscribed(subscriber []byte, identifier string, topic string, bucket uint32) (bool, error)
 	GetSubscribers(topic string, bucket uint32) []string
 	GetSubscribersCount(topic string, bucket uint32) int
+	GetFreeTopicBucket(topic string) int
 	GetTopicBucketsCount(topic string) uint32
 
 	GetContract(codeHash Uint160) ([]byte, error)

--- a/core/transaction/builder.go
+++ b/core/transaction/builder.go
@@ -182,11 +182,12 @@ func NewDeleteNameTransaction(registrant []byte) (*Transaction, error) {
 	}, nil
 }
 
-func NewSubscribeTransaction(subscriber []byte, identifier string, topic string, duration uint32) (*Transaction, error) {
+func NewSubscribeTransaction(subscriber []byte, identifier string, topic string, bucket uint32, duration uint32) (*Transaction, error) {
 	SubscribePayload := &payload.Subscribe{
 		Subscriber: subscriber,
 		Identifier: identifier,
 		Topic: topic,
+		Bucket: bucket,
 		Duration: duration,
 	}
 

--- a/core/transaction/payload/Subscribe.go
+++ b/core/transaction/payload/Subscribe.go
@@ -15,6 +15,7 @@ type Subscribe struct {
 	Subscriber []byte
 	Identifier string
 	Topic      string
+	Bucket     uint32
 	Duration   uint32
 }
 
@@ -28,6 +29,7 @@ func (s *Subscribe) Serialize(w io.Writer, version byte) error {
 	serialization.WriteVarBytes(w, s.Subscriber)
 	serialization.WriteVarString(w, s.Identifier)
 	serialization.WriteVarString(w, s.Topic)
+	serialization.WriteUint32(w, s.Bucket)
 	serialization.WriteUint32(w, s.Duration)
 	return nil
 }
@@ -45,6 +47,10 @@ func (s *Subscribe) Deserialize(r io.Reader, version byte) error {
 	s.Topic, err = serialization.ReadVarString(r)
 	if err != nil {
 		return NewDetailErr(err, ErrNoCode, "[Subscribe], Topic Deserialize failed.")
+	}
+	s.Bucket, err = serialization.ReadUint32(r)
+	if err != nil {
+		return NewDetailErr(err, ErrNoCode, "[Subscribe], Bucket Deserialize failed.")
 	}
 	s.Duration, err = serialization.ReadUint32(r)
 	if err != nil {
@@ -66,6 +72,10 @@ func (s *Subscribe) Equal(s2 *Subscribe) bool {
 		return false
 	}
 
+	if s.Bucket != s2.Bucket {
+		return false
+	}
+
 	if s.Duration != s2.Duration {
 		return false
 	}
@@ -82,6 +92,7 @@ func (s *Subscribe) MarshalJson() ([]byte, error) {
 		Subscriber: common.BytesToHexString(s.Subscriber),
 		Identifier: s.Identifier,
 		Topic:      s.Topic,
+		Bucket:     s.Bucket,
 		Duration:   s.Duration,
 	}
 
@@ -104,6 +115,8 @@ func (s *Subscribe) UnmarshalJson(data []byte) error {
 	s.Identifier = si.Identifier
 
 	s.Topic = si.Topic
+
+	s.Bucket = si.Bucket
 
 	s.Duration = si.Duration
 

--- a/core/transaction/payload/jsontype.go
+++ b/core/transaction/payload/jsontype.go
@@ -42,5 +42,6 @@ type SubscribeInfo struct {
 	Subscriber string `json:"subscriber"`
 	Identifier string `json:"identifier"`
 	Topic      string `json:"topic"`
+	Bucket     uint32 `json:"bucket"`
 	Duration   uint32 `json:"duration"`
 }

--- a/core/transaction/validator.go
+++ b/core/transaction/validator.go
@@ -72,6 +72,9 @@ func VerifyTransaction(Tx *Transaction) ErrCode {
 
 	if err := CheckTransactionPayload(Tx); err != nil {
 		log.Warning("[VerifyTransaction],", err)
+		if err, ok := err.(ErrCode); ok {
+			return err
+		}
 		return ErrTransactionPayload
 	}
 
@@ -413,7 +416,7 @@ func CheckTransactionPayload(txn *Transaction) error {
 
 		subscriptionCount := Store.GetSubscribersCount(topic, bucket)
 		if subscriptionCount >= SubscriptionsLimit {
-			return errors.New(fmt.Sprintf("subscribtion count to %s can't be more than %d", topic, subscriptionCount))
+			return ErrSubscriptionLimit
 		}
 	default:
 		return errors.New("[txValidator],invalidate transaction payload type.")

--- a/core/transaction/validator.go
+++ b/core/transaction/validator.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	SubscriptionsLimit = 1000
+	BucketsLimit = 1000
 	MaxSubscriptionDuration = 65535
 )
 
@@ -383,6 +384,11 @@ func CheckTransactionPayload(txn *Transaction) error {
 			return errors.New(fmt.Sprintf("no name registered for pubKey %+v", pld.Registrant))
 		}
 	case *payload.Subscribe:
+		bucket := pld.Bucket
+		if bucket > BucketsLimit {
+			return errors.New(fmt.Sprintf("topic bucket %d can't be bigger than %d", bucket, BucketsLimit))
+		}
+
 		duration := pld.Duration
 		if duration > MaxSubscriptionDuration {
 			return errors.New(fmt.Sprintf("subscription duration %d can't be bigger than %d", duration, MaxSubscriptionDuration))
@@ -397,7 +403,6 @@ func CheckTransactionPayload(txn *Transaction) error {
 			return errors.New(fmt.Sprintf("topic %s should only contain a-z and have length 8-12", topic))
 		}
 
-		bucket := pld.Bucket
 		subscribed, err := Store.IsSubscribed(pld.Subscriber, pld.Identifier, topic, bucket)
 		if err != nil {
 			return err

--- a/db/rollback.go
+++ b/db/rollback.go
@@ -262,7 +262,7 @@ func (cs *ChainStore) rollbackPubSub(b *ledger.Block) error {
 	for _, txn := range b.Transactions {
 		if txn.TxType == tx.Subscribe {
 			subscribePayload := txn.Payload.(*payload.Subscribe)
-			err := cs.Unsubscribe(subscribePayload.Subscriber, subscribePayload.Identifier, subscribePayload.Topic, subscribePayload.Duration, height)
+			err := cs.Unsubscribe(subscribePayload.Subscriber, subscribePayload.Identifier, subscribePayload.Topic, subscribePayload.Bucket, subscribePayload.Duration, height)
 			if err != nil {
 				return err
 			}

--- a/db/store.go
+++ b/db/store.go
@@ -672,7 +672,7 @@ func (cs *ChainStore) GetSubscribersCount(topic string, bucket uint32) int {
 	return subscribers
 }
 
-func (cs *ChainStore) GetFreeTopicBucket(topic string) int {
+func (cs *ChainStore) GetFirstAvailableTopicBucket(topic string) int {
 	for i := uint32(0); i < tx.BucketsLimit; i++ {
 		count := cs.GetSubscribersCount(topic, i)
 		if count < tx.SubscriptionsLimit {

--- a/db/store.go
+++ b/db/store.go
@@ -672,6 +672,17 @@ func (cs *ChainStore) GetSubscribersCount(topic string, bucket uint32) int {
 	return subscribers
 }
 
+func (cs *ChainStore) GetFreeTopicBucket(topic string) int {
+	for i := uint32(0); i < tx.BucketsLimit; i++ {
+		count := cs.GetSubscribersCount(topic, i)
+		if count < tx.SubscriptionsLimit {
+			return int(i)
+		}
+	}
+
+	return -1
+}
+
 func (cs *ChainStore) GetTopicBucketsCount(topic string) uint32 {
 	lastBucket := uint32(0)
 


### PR DESCRIPTION
Signed-off-by: Nikolai Perevozchikov <insider@nkn.org>

### Proposed changes in this pull request
Each subscription topic is separated to buckets with 1000 subscriptions limit each. This is done so that topic could have more subscriptions than this limit inside different buckets.

**NOTE:** This is a breaking change that will require reset of the chain to genesis.

### Type
- [ ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [x] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
https://github.com/nknorg/nkn-client-js/pull/38
https://github.com/nknorg/nkn-wallet-js/pull/17