### PR TITLE
Accept wallet password from NKN_PASSWORD environment variable

### DIFF
--- a/cli/wallet/wallet.go
+++ b/cli/wallet/wallet.go
@@ -63,7 +63,11 @@ func walletAction(c *cli.Context) error {
 		fmt.Fprintln(os.Stderr, "invalid wallet name")
 		os.Exit(1)
 	}
+	// get password from the command line or from environment variable
 	passwd := c.String("password")
+	if passwd == "" {
+		passwd = os.Getenv("NKN_PASSWORD")
+	}
 
 	// create wallet
 	if c.Bool("create") {

--- a/cli/wallet/wallet.go
+++ b/cli/wallet/wallet.go
@@ -66,7 +66,7 @@ func walletAction(c *cli.Context) error {
 	// get password from the command line or from environment variable
 	passwd := c.String("password")
 	if passwd == "" {
-		passwd = os.Getenv("NKN_PASSWORD")
+		passwd = os.Getenv("NKN_WALLET_PASSWORD")
 	}
 
 	// create wallet

--- a/util/password/password.go
+++ b/util/password/password.go
@@ -52,8 +52,12 @@ func GetConfirmedPassword() ([]byte, error) {
 	return first, nil
 }
 
-// GetPassword gets node's wallet password from command line or user input
+// GetAccountPassword gets the node's wallet password from the command line,
+// the NKN_PASSWORD environment variable, or from user input - in this order
 func GetAccountPassword() ([]byte, error) {
+	if Passwd == "" {
+		Passwd = os.Getenv("NKN_PASSWORD")
+	}
 	if Passwd == "" {
 		return GetPassword()
 	}

--- a/util/password/password.go
+++ b/util/password/password.go
@@ -53,10 +53,10 @@ func GetConfirmedPassword() ([]byte, error) {
 }
 
 // GetAccountPassword gets the node's wallet password from the command line,
-// the NKN_PASSWORD environment variable, or from user input - in this order
+// the NKN_WALLET_PASSWORD environment variable, or user input, in this order
 func GetAccountPassword() ([]byte, error) {
 	if Passwd == "" {
-		Passwd = os.Getenv("NKN_PASSWORD")
+		Passwd = os.Getenv("NKN_WALLET_PASSWORD")
 	}
 	if Passwd == "" {
 		return GetPassword()


### PR DESCRIPTION
### Proposed changes in this pull request
Passing the password non-interactively from Docker is safer from an environment variable than from the command-line, since a simple `ps aux` by any user will display the user wallet's password!

The *root* user can still see a container's environment, though, by running `docker inspect`. So the safest method remains getting the password from user input. For this reason, I found it better to follow the `-p|--password` example and not document it.

`-p|--password` takes precedence over `$NKN_PASSWORD`.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [x] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)
