### PR TITLE
make new subscribe payload compatible with old ledger data

### DIFF
--- a/core/transaction/builder.go
+++ b/core/transaction/builder.go
@@ -193,6 +193,7 @@ func NewSubscribeTransaction(subscriber []byte, identifier string, topic string,
 
 	return &Transaction{
 		TxType:  Subscribe,
+		PayloadVersion: 1,
 		Payload: SubscribePayload,
 		Attributes: []*TxnAttribute{
 			{

--- a/core/transaction/payload/Subscribe.go
+++ b/core/transaction/payload/Subscribe.go
@@ -29,7 +29,9 @@ func (s *Subscribe) Serialize(w io.Writer, version byte) error {
 	serialization.WriteVarBytes(w, s.Subscriber)
 	serialization.WriteVarString(w, s.Identifier)
 	serialization.WriteVarString(w, s.Topic)
-	serialization.WriteUint32(w, s.Bucket)
+	if version == 1 {
+		serialization.WriteUint32(w, s.Bucket)
+	}
 	serialization.WriteUint32(w, s.Duration)
 	return nil
 }
@@ -48,9 +50,11 @@ func (s *Subscribe) Deserialize(r io.Reader, version byte) error {
 	if err != nil {
 		return NewDetailErr(err, ErrNoCode, "[Subscribe], Topic Deserialize failed.")
 	}
-	s.Bucket, err = serialization.ReadUint32(r)
-	if err != nil {
-		return NewDetailErr(err, ErrNoCode, "[Subscribe], Bucket Deserialize failed.")
+	if version == 1 {
+		s.Bucket, err = serialization.ReadUint32(r)
+		if err != nil {
+			return NewDetailErr(err, ErrNoCode, "[Subscribe], Bucket Deserialize failed.")
+		}
 	}
 	s.Duration, err = serialization.ReadUint32(r)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Nikolai Perevozchikov <insider@nkn.org>

### Proposed changes in this pull request
Make new subscribe payload compatible with old ledger data so that no ledger reset would be required to update.

### Type
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
https://github.com/nknorg/nkn-wallet-js/pull/18