### PR TITLE
propagate already subscribed error to RPC client

### DIFF
--- a/core/transaction/validator.go
+++ b/core/transaction/validator.go
@@ -422,7 +422,7 @@ func CheckTransactionPayload(txn *Transaction) error {
 			return err
 		}
 		if subscribed {
-			return errors.New(fmt.Sprintf("subscriber %s already subscribed to %s", pld.SubscriberString(), topic))
+			return ErrAlreadySubscribed
 		}
 
 		subscriptionCount := Store.GetSubscribersCount(topic, bucket)

--- a/errors/errcode.go
+++ b/errors/errcode.go
@@ -35,6 +35,7 @@ const (
 	ErrDuplicateSubscription ErrCode = 45017
 	ErrSubscriptionLimit     ErrCode = 45018
 	ErrDoNotPropagate        ErrCode = 45019
+	ErrAlreadySubscribed     ErrCode = 45020
 )
 
 var ErrCode2Str = map[ErrCode]string{
@@ -60,6 +61,7 @@ var ErrCode2Str = map[ErrCode]string{
 	ErrDuplicateSubscription: "Duplicate subscription in one block",
 	ErrSubscriptionLimit:     "Subscription limit exceeded in one block",
 	ErrDoNotPropagate:        "Transaction should not be further propagated",
+	ErrAlreadySubscribed:     "Client already subscribed to topic",
 }
 
 func (err ErrCode) Error() string {


### PR DESCRIPTION
Signed-off-by: Nikolai Perevozchikov <insider@nkn.org>

### Proposed changes in this pull request
Propagate "already subscribed" error to RPC client (to be able to ignore it on client side, since it's not critical, etc)

### Type
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)