### PR TITLE
Fix memory leak, bandwidth usage and NAT detect by upgrading nnet

### DIFF
--- a/api/common/interfaces.go
+++ b/api/common/interfaces.go
@@ -56,10 +56,14 @@ func (ah *APIHandler) IsAccessableByWebsocket() bool {
 // params: []
 // return: {"result":<result>, "error":<errcode>}
 func getLatestBlockHash(s Serverer, params map[string]interface{}) map[string]interface{} {
-	hash := ledger.DefaultLedger.Blockchain.CurrentBlockHash()
+	height := ledger.DefaultLedger.Store.GetHeight()
+	hash, err := ledger.DefaultLedger.Store.GetBlockHash(height)
+	if err != nil {
+		return respPacking(nil, INTERNAL_ERROR)
+	}
 	ret := map[string]interface{}{
-		"height": ledger.DefaultLedger.Blockchain.BlockHeight,
-		"hash":   common.BytesToHexString(hash.ToArrayReverse()),
+		"height": height,
+		"hash":   hash.ToHexString(),
 	}
 	return respPacking(ret, SUCCESS)
 }
@@ -108,7 +112,7 @@ func getBlock(s Serverer, params map[string]interface{}) map[string]interface{} 
 // params: []
 // return: {"result":<result>, "error":<errcode>}
 func getBlockCount(s Serverer, params map[string]interface{}) map[string]interface{} {
-	return respPacking(ledger.DefaultLedger.Blockchain.BlockHeight+1, SUCCESS)
+	return respPacking(ledger.DefaultLedger.Store.GetHeight()+1, SUCCESS)
 }
 
 // getChordRingInfo gets the information of Chord
@@ -126,7 +130,7 @@ func getChordRingInfo(s Serverer, params map[string]interface{}) map[string]inte
 // params: []
 // return: {"result":<result>, "error":<errcode>}
 func getLatestBlockHeight(s Serverer, params map[string]interface{}) map[string]interface{} {
-	return respPacking(ledger.DefaultLedger.Blockchain.BlockHeight, SUCCESS)
+	return respPacking(ledger.DefaultLedger.Store.GetHeight(), SUCCESS)
 }
 
 //// getBlockHash gets the block hash by height

--- a/consensus/moca/proposal.go
+++ b/consensus/moca/proposal.go
@@ -232,7 +232,7 @@ func (consensus *Consensus) receiveProposal(block *ledger.Block) error {
 // receiveProposalHash is called when a node receives a block proposal hash from
 // a neighbor
 func (consensus *Consensus) receiveProposalHash(neighborID string, height uint32, blockHash common.Uint256) error {
-	log.Debugf("Receive block hash %s for height %d from neighbor %d", blockHash.ToHexString(), height, neighborID)
+	log.Debugf("Receive block hash %s for height %d from neighbor %v", blockHash.ToHexString(), height, neighborID)
 
 	if blockHash == common.EmptyUint256 {
 		return errors.New("Receive empty block hash")

--- a/consensus/moca/vote.go
+++ b/consensus/moca/vote.go
@@ -8,7 +8,7 @@ import (
 
 // receiveVote is called when a vote from neighbor is received
 func (consensus *Consensus) receiveVote(neighborID string, height uint32, blockHash common.Uint256) error {
-	log.Debugf("Receive vote %s for height %d from neighbor %s", blockHash.ToHexString(), height, neighborID)
+	log.Debugf("Receive vote %s for height %d from neighbor %v", blockHash.ToHexString(), height, neighborID)
 
 	if blockHash != common.EmptyUint256 {
 		err := consensus.receiveProposalHash(neighborID, height, blockHash)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 8560b3563e7b15a9e0ab39f71dd6da2e29ce7ed4aca35c97d11ac9ac3c75b0b7
-updated: 2019-01-16T21:02:21.803237-08:00
+updated: 2019-01-23T03:05:37.073522-08:00
 imports:
 - name: github.com/gogo/protobuf
   version: 636bf0302bc95575d69441b25a2603156ffdddf1
@@ -11,7 +11,7 @@ imports:
   - sortkeys
   - types
 - name: github.com/golang/crypto
-  version: ff983b9c42bc9fbf91556e191cc8efb585c16908
+  version: 057139ce5d2bdbe6fe73c53679e24e9cf007f637
   subpackages:
   - ripemd160
   - ssh/terminal
@@ -55,7 +55,7 @@ imports:
 - name: github.com/nknorg/gopass
   version: 9ddc09fe41c891b7987acd1bf75f9067a56c17f5
 - name: github.com/nknorg/nnet
-  version: 5e7a25cc73ae6a6652238ba84f4d17a5cb655d72
+  version: b477418fc56b5152598892b4d05ff41a4082394d
   subpackages:
   - cache
   - common
@@ -109,7 +109,7 @@ imports:
 - name: github.com/xtaci/smux
   version: 6cf098d439391c8f8f6a485f8928f47575b6002e
 - name: golang.org/x/crypto
-  version: ff983b9c42bc9fbf91556e191cc8efb585c16908
+  version: 057139ce5d2bdbe6fe73c53679e24e9cf007f637
   repo: https://github.com/golang/crypto
   vcs: git
   subpackages:
@@ -123,7 +123,7 @@ imports:
   - twofish
   - xtea
 - name: golang.org/x/net
-  version: 915654e7eabcea33ae277abbecf52f0d8b7a9fdc
+  version: ed066c81e75eba56dd9bd2139ade88125b855585
   repo: https://github.com/golang/net
   vcs: git
   subpackages:
@@ -135,7 +135,7 @@ imports:
   - internal/socket
   - ipv4
 - name: golang.org/x/sys
-  version: 11f53e03133963fb11ae0588e08b5e0b85be8be5
+  version: c6b37f3e92850b723493d63fd35aad34e19e048d
   repo: https://github.com/golang/sys
   vcs: git
   subpackages:

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -126,10 +126,12 @@ func Init() error {
 	}
 
 	if Parameters.Hostname == "" {
+		log.Println("Getting my IP address...")
 		ip, err := ipify.GetIp()
 		if err != nil {
 			return err
 		}
+		log.Printf("My IP address is %s", ip)
 
 		Parameters.Hostname = ip
 


### PR DESCRIPTION
Fix several problems by upgrading to latest nnet version:
* Fix memory leak caused by stopped nodes
* Reduce bandwidth usage by inceasing stabilize/ping interval
* Prevent unreachable nodes from having predecessors

Signed-off-by: Yilun <zyl.skysniper@gmail.com>

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
