### PR TITLE
[Bugfix] Default RPC R/W timeout for recycled idle fd

### DIFF
--- a/api/httpjson/RPCserver.go
+++ b/api/httpjson/RPCserver.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/nknorg/nkn/api/common"
 	"github.com/nknorg/nkn/errors"
@@ -223,7 +224,9 @@ func (s *RPCServer) Start() {
 	rpcServeMux := http.NewServeMux()
 	rpcServeMux.HandleFunc("/", s.Handle)
 	httpServer := &http.Server{
-		Handler: rpcServeMux,
+		Handler:      rpcServeMux,
+		ReadTimeout:  config.Parameters.RPCReadTimeout * time.Second,
+		WriteTimeout: config.Parameters.RPCWriteTimeout * time.Second,
 	}
 	httpServer.Serve(listener)
 }

--- a/api/httpjson/RPCserver.go
+++ b/api/httpjson/RPCserver.go
@@ -227,6 +227,7 @@ func (s *RPCServer) Start() {
 		Handler:      rpcServeMux,
 		ReadTimeout:  config.Parameters.RPCReadTimeout * time.Second,
 		WriteTimeout: config.Parameters.RPCWriteTimeout * time.Second,
+		IdleTimeout:  config.Parameters.KeepAliveTimeout * time.Second,
 	}
 	httpServer.Serve(listener)
 }

--- a/api/websocket/server/server.go
+++ b/api/websocket/server/server.go
@@ -93,10 +93,7 @@ func (ws *WsServer) Start() error {
 	var done = make(chan bool)
 	go ws.checkSessionsTimeout(done)
 
-	ws.server = &http.Server{Handler: http.HandlerFunc(ws.websocketHandler),
-		ReadTimeout:  config.Parameters.RPCReadTimeout * time.Second,
-		WriteTimeout: config.Parameters.RPCWriteTimeout * time.Second,
-	}
+	ws.server = &http.Server{Handler: http.HandlerFunc(ws.websocketHandler)}
 	err := ws.server.Serve(ws.listener)
 
 	done <- true

--- a/api/websocket/server/server.go
+++ b/api/websocket/server/server.go
@@ -93,7 +93,10 @@ func (ws *WsServer) Start() error {
 	var done = make(chan bool)
 	go ws.checkSessionsTimeout(done)
 
-	ws.server = &http.Server{Handler: http.HandlerFunc(ws.websocketHandler)}
+	ws.server = &http.Server{Handler: http.HandlerFunc(ws.websocketHandler),
+		ReadTimeout:  config.Parameters.RPCReadTimeout * time.Second,
+		WriteTimeout: config.Parameters.RPCWriteTimeout * time.Second,
+	}
 	err := ws.server.Serve(ws.listener)
 
 	done <- true

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -51,6 +51,7 @@ var (
 		SyncBlocksBatchSize:       8,
 		RPCReadTimeout:            5,
 		RPCWriteTimeout:           10,
+		KeepAliveTimeout:          15,
 	}
 )
 
@@ -84,6 +85,7 @@ type Configuration struct {
 	SyncBlocksBatchSize       uint32        `json:"SyncBlocksBatchSize"`
 	RPCReadTimeout            time.Duration `json:"RPCReadTimeout"`
 	RPCWriteTimeout           time.Duration `json:"RPCWriteTimeout"`
+	KeepAliveTimeout          time.Duration `json:"KeepAliveTimeout"`
 }
 
 func Init() error {

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -36,50 +36,54 @@ var (
 	SkipCheckPort bool
 	SkipNAT       bool
 	Parameters    = &Configuration{
-		Version:       1,
-		Transport:     "tcp",
-		NodePort:      30001,
-		HttpWsPort:    30002,
-		HttpJsonPort:  30003,
-		NAT:           true,
-		LogLevel:      1,
+		Version:      1,
+		Transport:    "tcp",
+		NodePort:     30001,
+		HttpWsPort:   30002,
+		HttpJsonPort: 30003,
+		NAT:          true,
+		LogLevel:     1,
 		SeedList: []string{
 			"http://127.0.0.1:30003",
 		},
 		SyncBatchWindowSize:       1024,
 		SyncBlockHeadersBatchSize: 256,
 		SyncBlocksBatchSize:       8,
+		RPCReadTimeout:            5,
+		RPCWriteTimeout:           10,
 	}
 )
 
 type Configuration struct {
-	Version                   int      `json:"Version"`
-	SeedList                  []string `json:"SeedList"`
-	RestCertPath              string   `json:"RestCertPath"`
-	RestKeyPath               string   `json:"RestKeyPath"`
-	RPCCert                   string   `json:"RPCCert"`
-	RPCKey                    string   `json:"RPCKey"`
-	HttpWsPort                uint16   `json:"HttpWsPort"`
-	HttpJsonPort              uint16   `json:"HttpJsonPort"`
-	NodePort                  uint16   `json:"-"`
-	LogLevel                  int      `json:"LogLevel"`
-	IsTLS                     bool     `json:"IsTLS"`
-	CertPath                  string   `json:"CertPath"`
-	KeyPath                   string   `json:"KeyPath"`
-	CAPath                    string   `json:"CAPath"`
-	GenBlockTime              uint     `json:"GenBlockTime"`
-	EncryptAlg                string   `json:"EncryptAlg"`
-	MaxLogSize                int64    `json:"MaxLogSize"`
-	MaxTxInBlock              int      `json:"MaxTransactionInBlock"`
-	MaxHdrSyncReqs            int      `json:"MaxConcurrentSyncHeaderReqs"`
-	GenesisBlockProposer      string   `json:"GenesisBlockProposer"`
-	Hostname                  string   `json:"Hostname"`
-	Transport                 string   `json:"Transport"`
-	NAT                       bool     `json:"NAT"`
-	BeneficiaryAddr           string   `json:"BeneficiaryAddr"`
-	SyncBatchWindowSize       uint32   `json:"SyncBatchWindowSize"`
-	SyncBlockHeadersBatchSize uint32   `json:"SyncBlockHeadersBatchSize"`
-	SyncBlocksBatchSize       uint32   `json:"SyncBlocksBatchSize"`
+	Version                   int           `json:"Version"`
+	SeedList                  []string      `json:"SeedList"`
+	RestCertPath              string        `json:"RestCertPath"`
+	RestKeyPath               string        `json:"RestKeyPath"`
+	RPCCert                   string        `json:"RPCCert"`
+	RPCKey                    string        `json:"RPCKey"`
+	HttpWsPort                uint16        `json:"HttpWsPort"`
+	HttpJsonPort              uint16        `json:"HttpJsonPort"`
+	NodePort                  uint16        `json:"-"`
+	LogLevel                  int           `json:"LogLevel"`
+	IsTLS                     bool          `json:"IsTLS"`
+	CertPath                  string        `json:"CertPath"`
+	KeyPath                   string        `json:"KeyPath"`
+	CAPath                    string        `json:"CAPath"`
+	GenBlockTime              uint          `json:"GenBlockTime"`
+	EncryptAlg                string        `json:"EncryptAlg"`
+	MaxLogSize                int64         `json:"MaxLogSize"`
+	MaxTxInBlock              int           `json:"MaxTransactionInBlock"`
+	MaxHdrSyncReqs            int           `json:"MaxConcurrentSyncHeaderReqs"`
+	GenesisBlockProposer      string        `json:"GenesisBlockProposer"`
+	Hostname                  string        `json:"Hostname"`
+	Transport                 string        `json:"Transport"`
+	NAT                       bool          `json:"NAT"`
+	BeneficiaryAddr           string        `json:"BeneficiaryAddr"`
+	SyncBatchWindowSize       uint32        `json:"SyncBatchWindowSize"`
+	SyncBlockHeadersBatchSize uint32        `json:"SyncBlockHeadersBatchSize"`
+	SyncBlocksBatchSize       uint32        `json:"SyncBlocksBatchSize"`
+	RPCReadTimeout            time.Duration `json:"RPCReadTimeout"`
+	RPCWriteTimeout           time.Duration `json:"RPCWriteTimeout"`
 }
 
 func Init() error {


### PR DESCRIPTION
Abnormal/vicious rpc occupied fd for a long time, which will cause
"too many open files". Set maximum R/W timeout in order to recycled
those idle/slowly connection.

Signed-off-by: gdmmx <gdmmx@163.com>

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
