### PR TITLE
Optimize dockerfile for smaller size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-stretch
+FROM golang:1.10-stretch AS build
 LABEL maintainer="gdmmx@nkn.org"
 
 # apt-get
@@ -23,4 +23,9 @@ RUN make vendor
 RUN make
 RUN cp nknd nknc /usr/local/go/bin/
 
+WORKDIR /nkn
+
+FROM buildpack-deps:stretch-scm
+COPY --from=build /go/src/github.com/nknorg/nkn/nknd /usr/local/bin/
+COPY --from=build /go/src/github.com/nknorg/nkn/nknc /usr/local/bin/
 WORKDIR /nkn


### PR DESCRIPTION
Signed-off-by: Zihan Tang <mrzihan.tang@gmail.com>

### Proposed changes in this pull request
With current dockerfile, I built a extremely huge image. I opened this PR for a docker image with smaller size.
```
nkn                 v0.7.3-alpha        d0c7f1b304b8        4 minutes ago       294MB
<none>              <none>              1d5b69140cd7        5 minutes ago       1.09GB
```
It will reduce the image from 1.09GB to something like 294MB.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [x] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [N/A] All the tests are passing after the introduction of new changes.
- [N/A] Added tests respective to the part of code I have written.
- [N/A] Added proper documentation where ever applicable (in code and README.md).
- [N/A] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
I assumed that change of dockerfile will not change the code itself.
