### PR TITLE
Change AddPortMapping timeout overflow to int

### DIFF
--- a/util/config/config.go
+++ b/util/config/config.go
@@ -164,19 +164,19 @@ func (config *Configuration) addPortMapping(nat gonat.NAT) error {
 		return err
 	}
 
-	externalPort, internalPort, err := nat.AddPortMapping(transport.GetNetwork(), int(config.NodePort), int(config.NodePort), "nkn", 10*time.Second)
+	externalPort, internalPort, err := nat.AddPortMapping(transport.GetNetwork(), int(config.NodePort), int(config.NodePort), "nkn", 10)
 	if err != nil {
 		return err
 	}
 	log.Printf("Mapped external port %d to internal port %d", externalPort, internalPort)
 
-	externalPort, internalPort, err = nat.AddPortMapping(transport.GetNetwork(), int(config.HttpWsPort), int(config.HttpWsPort), "nkn", 10*time.Second)
+	externalPort, internalPort, err = nat.AddPortMapping(transport.GetNetwork(), int(config.HttpWsPort), int(config.HttpWsPort), "nkn", 10)
 	if err != nil {
 		return err
 	}
 	log.Printf("Mapped external port %d to internal port %d", externalPort, internalPort)
 
-	externalPort, internalPort, err = nat.AddPortMapping(transport.GetNetwork(), int(config.HttpJsonPort), int(config.HttpJsonPort), "nkn", 10*time.Second)
+	externalPort, internalPort, err = nat.AddPortMapping(transport.GetNetwork(), int(config.HttpJsonPort), int(config.HttpJsonPort), "nkn", 10)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
UPnP would execute to my router and then subsequently be removed, replacing the calculation of 10*time.second with just 10, the UPnP mapping completes and is not removed. Allowing users to not have have to forward ports if they have UPnP working.

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
