### PR TITLE
Change fieldType of uptime and nknc support export privKey

### DIFF
--- a/cli/wallet/wallet.go
+++ b/cli/wallet/wallet.go
@@ -13,13 +13,17 @@ import (
 	"github.com/urfave/cli"
 )
 
-func showAccountInfo(wallet vault.Wallet) {
+func showAccountInfo(wallet vault.Wallet, verbose bool) {
+	const format = "%-34s  %s\n"
 	account, _ := wallet.GetDefaultAccount()
-	fmt.Println("Address\t\t\t\t Public Key")
-	fmt.Println("-------\t\t\t\t ----------")
+	fmt.Printf(format, "Address", "Public Key")
+	fmt.Printf(format, "-------", "----------")
 	address, _ := account.ProgramHash.ToAddress()
 	publicKey, _ := account.PublicKey.EncodePoint(true)
-	fmt.Printf("%s %s\n", address, BytesToHexString(publicKey))
+	fmt.Printf(format, address, BytesToHexString(publicKey))
+	if verbose {
+		fmt.Printf("\nPrivate Key\n-----------\n%s\n", BytesToHexString(account.PrivateKey))
+	}
 }
 
 func getPassword(passwd string) []byte {
@@ -80,7 +84,7 @@ func walletAction(c *cli.Context) error {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
-			showAccountInfo(wallet)
+			showAccountInfo(wallet, false)
 		}
 		return nil
 	}
@@ -96,9 +100,13 @@ func walletAction(c *cli.Context) error {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
+			var vbs bool
 			switch item {
+			case "verbose":
+				vbs = true
+				fallthrough
 			case "account":
-				showAccountInfo(wallet)
+				showAccountInfo(wallet, vbs)
 			case "balance":
 				account, _ := wallet.GetDefaultAccount()
 				address, _ := account.ProgramHash.ToAddress()

--- a/net/node/localnode.go
+++ b/net/node/localnode.go
@@ -63,7 +63,7 @@ func (localNode *LocalNode) MarshalJSON() ([]byte, error) {
 	}
 
 	out["height"] = localNode.GetHeight()
-	out["uptime"] = time.Since(localNode.startTime).Truncate(time.Second).String()
+	out["uptime"] = time.Since(localNode.startTime).Truncate(time.Second).Seconds()
 	out["version"] = config.Version
 	out["relayMessageCount"] = localNode.GetRelayMessageCount()
 


### PR DESCRIPTION
Signed-off-by: gdmmx <gdmmx@163.com>

### Proposed changes in this pull request
Enhance nknc functionality, support export privateKey by verbose flag
Adjust fieldType of uptime from string to int

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.