### PR TITLE
Fully decentralize how block proposer is selected

### DIFF
--- a/consensus/moca/config.go
+++ b/consensus/moca/config.go
@@ -7,14 +7,13 @@ import (
 )
 
 const (
-	maxNumTxnPerBlock           = 20480
-	electionStartDelay          = 10 * time.Second
-	electionDuration            = 10 * time.Second
+	electionStartDelay          = config.ConsensusDuration / 2
+	electionDuration            = config.ConsensusDuration / 2
 	minVotingInterval           = 500 * time.Millisecond
 	proposingInterval           = 500 * time.Millisecond
 	cacheExpiration             = 3600 * time.Second
 	cacheCleanupInterval        = 600 * time.Second
-	proposingStartDelay         = config.ProposerChangeTime + time.Second
+	proposingStartDelay         = config.ConsensusTimeout + time.Second
 	getConsensusStateInterval   = 30 * time.Second
 	getConsensusStateRetries    = 3
 	getConsensusStateRetryDelay = 3 * time.Second

--- a/consensus/moca/consensus.go
+++ b/consensus/moca/consensus.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nknorg/nkn/core/transaction"
 	"github.com/nknorg/nkn/net/node"
 	"github.com/nknorg/nkn/pb"
+	"github.com/nknorg/nkn/util/config"
 	"github.com/nknorg/nkn/util/log"
 	"github.com/nknorg/nkn/vault"
 )
@@ -43,7 +44,7 @@ type Consensus struct {
 
 // NewConsensus creates a MOCA consensus
 func NewConsensus(account *vault.Account, localNode *node.LocalNode) (*Consensus, error) {
-	txnCollector := transaction.NewTxnCollector(localNode.GetTxnPool(), maxNumTxnPerBlock)
+	txnCollector := transaction.NewTxnCollector(localNode.GetTxnPool(), config.MaxNumTxnPerBlock)
 	consensus := &Consensus{
 		account:             account,
 		localNode:           localNode,

--- a/core/ledger/validator.go
+++ b/core/ledger/validator.go
@@ -105,16 +105,19 @@ func GetNextBlockSigner(height uint32, timestamp int64) ([]byte, []byte, WinnerT
 		return nil, nil, 0, fmt.Errorf("timestamp %d is earlier than previous block timestamp %d", timestamp, header.Timestamp)
 	}
 
-	// calculate time difference
 	timeSinceLastBlock := timestamp - header.Timestamp
-	timeSlot := int64(config.ProposerChangeTime / time.Second)
+	proposerChangeTime := int64(config.ConsensusTimeout.Seconds())
 
-	if timeSinceLastBlock >= timeSlot {
+	if proposerChangeTime-timeSinceLastBlock%proposerChangeTime <= int64(config.ConsensusDuration.Seconds()) {
+		return nil, nil, 0, nil
+	}
+
+	if timeSinceLastBlock >= proposerChangeTime {
 		winnerType = BlockSigner
 
 		// This is a temporary solution
 		proposerBlockHeight := 0
-		// index := timeSinceLastBlock / timeSlot
+		// index := timeSinceLastBlock / proposerChangeTime
 		// proposerBlockHeight := int64(DefaultLedger.Store.GetHeight()) - index
 		// if proposerBlockHeight < 0 {
 		// proposerBlockHeight = 0

--- a/core/ledger/validator.go
+++ b/core/ledger/validator.go
@@ -115,13 +115,10 @@ func GetNextBlockSigner(height uint32, timestamp int64) ([]byte, []byte, WinnerT
 	if timeSinceLastBlock >= proposerChangeTime {
 		winnerType = BlockSigner
 
-		// This is a temporary solution
-		proposerBlockHeight := 0
-		// index := timeSinceLastBlock / proposerChangeTime
-		// proposerBlockHeight := int64(DefaultLedger.Store.GetHeight()) - index
-		// if proposerBlockHeight < 0 {
-		// proposerBlockHeight = 0
-		// }
+		proposerBlockHeight := int64(DefaultLedger.Store.GetHeight()) - timeSinceLastBlock/proposerChangeTime
+		if proposerBlockHeight < 0 {
+			proposerBlockHeight = 0
+		}
 
 		proposerBlockHash, err := DefaultLedger.Store.GetBlockHash(uint32(proposerBlockHeight))
 		if err != nil {
@@ -142,12 +139,12 @@ func GetNextBlockSigner(height uint32, timestamp int64) ([]byte, []byte, WinnerT
 			if err != nil {
 				return nil, nil, 0, err
 			}
-			payload, ok := txn.Payload.(*payload.Commit)
+			pld, ok := txn.Payload.(*payload.Commit)
 			if !ok {
 				return nil, nil, 0, errors.New("invalid transaction type")
 			}
 			sigchain := &por.SigChain{}
-			proto.Unmarshal(payload.SigChain, sigchain)
+			proto.Unmarshal(pld.SigChain, sigchain)
 			publicKey, chordID, err = sigchain.GetMiner()
 			if err != nil {
 				return nil, nil, 0, err

--- a/nknd.go
+++ b/nknd.go
@@ -235,7 +235,7 @@ func nknMain(c *cli.Context) error {
 
 	go func() {
 		for {
-			time.Sleep(config.ConsensusTime)
+			time.Sleep(config.ConsensusDuration)
 			if log.CheckIfNeedNewFile() {
 				log.ClosePrintLog()
 				log.Init(log.Path, os.Stdout)

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -23,8 +23,9 @@ const (
 )
 
 const (
-	ConsensusTime       = 18 * time.Second
-	ProposerChangeTime  = time.Minute
+	MaxNumTxnPerBlock   = 4096
+	ConsensusDuration   = 20 * time.Second
+	ConsensusTimeout    = time.Minute
 	DefaultMiningReward = 15
 	MinNumSuccessors    = 8
 	NodeIDBytes         = 32


### PR DESCRIPTION
* Use past block proposer instead of genesis block proposer when consensus timeout
* Add timestamp check to prevent overlapping proposals

This will be a significant breaking change

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [x] Feature (Breaking change)
- [ ] Documentation Improvement
