### PR TITLE
Add NATPortMappingTimeout in config and delete port mapping when exit

### DIFF
--- a/nknd.go
+++ b/nknd.go
@@ -116,6 +116,8 @@ func nknMain(c *cli.Context) error {
 	}
 	log.Log.SetDebugLevel(config.Parameters.LogLevel) // Update LogLevel after config.json loaded
 
+	defer config.Parameters.CleanPortMapping()
+
 	// Get local account
 	wallet := vault.GetWallet()
 	if wallet == nil {


### PR DESCRIPTION
* Make NATPortMappingTimeout configurable to resolve #442 
* Automatic remove port mapping when nknd exit

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
