### PR TITLE
Fix Log directory not created on windows

### DIFF
--- a/util/log/log.go
+++ b/util/log/log.go
@@ -239,14 +239,12 @@ func Errorf(format string, a ...interface{}) {
 func FileOpen(path string) (*os.File, error) {
 	if fi, err := os.Stat(path); err == nil {
 		if !fi.IsDir() {
-			return nil, fmt.Errorf("open %s: not a directory", path)
+			return nil, fmt.Errorf("%s is not a directory", path)
 		}
-	} else if os.IsNotExist(err) {
+	} else {
 		if err := os.MkdirAll(path, 0766); err != nil {
 			return nil, err
 		}
-	} else {
-		return nil, err
 	}
 
 	var currenttime string = time.Now().Format("2006-01-02_15.04.05")
@@ -270,7 +268,7 @@ func Init(a ...interface{}) {
 			case string:
 				logFile, err = FileOpen(o.(string))
 				if err != nil {
-					fmt.Println("error: open log file failed")
+					fmt.Printf("open log file %v failed: %v", o, err)
 					os.Exit(1)
 				}
 				writers = append(writers, logFile)


### PR DESCRIPTION
This is a bug in Go ( https://github.com/golang/go/issues/29119 ) but it's still better to fix it here now.

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
