### PR TITLE
Query self external IP & chordID via RPC to seedList, instead of ipify

### DIFF
--- a/api/common/interfaces.go
+++ b/api/common/interfaces.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"net"
+	"strings"
 
 	"github.com/gogo/protobuf/proto"
 	. "github.com/nknorg/nkn/block"
@@ -641,6 +643,32 @@ func getTopicBucketsCount(s Serverer, params map[string]interface{}) map[string]
 	return respPacking(count, SUCCESS)
 }
 
+// getMyExtIP get RPC client's external IP
+// params: ["address":<address>]
+// return: {"result":<result>, "error":<errcode>}
+func getMyExtIP(s Serverer, params map[string]interface{}) map[string]interface{} {
+	if len(params) < 1 {
+		return respPacking(nil, INVALID_PARAMS)
+	}
+
+	addr, ok := params["RemoteAddr"].(string)
+	if !ok || len(addr) == 0 {
+		log.Errorf("Invalid params: [%v, %v]", ok, addr)
+		return respPacking(nil, INVALID_PARAMS)
+	}
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		if strings.LastIndexByte(addr, ':') >= 0 {
+			log.Errorf("getMyExtIP met invalid params %v: %v", addr, err)
+			return respPacking(nil, INVALID_PARAMS)
+		}
+		host = addr // addr just only host, without port
+	}
+	ret := map[string]interface{}{"RemoteAddr": host}
+	return respPacking(ret, SUCCESS)
+}
+
 // findSuccessorAddrs find the successors of a key
 // params: ["address":<address>]
 // return: {"result":<result>, "error":<errcode>}
@@ -730,6 +758,7 @@ var InitialAPIHandlers = map[string]APIHandler{
 	"getsubscribers":               {Handler: getSubscribers, AccessCtrl: BIT_JSONRPC},
 	"getfirstavailabletopicbucket": {Handler: getFirstAvailableTopicBucket, AccessCtrl: BIT_JSONRPC},
 	"gettopicbucketscount":         {Handler: getTopicBucketsCount, AccessCtrl: BIT_JSONRPC},
+	"getmyextip":                   {Handler: getMyExtIP, AccessCtrl: BIT_JSONRPC},
 	"findsuccessoraddr":            {Handler: findSuccessorAddr, AccessCtrl: BIT_JSONRPC},
 	"findsuccessoraddrs":           {Handler: findSuccessorAddrs, AccessCtrl: BIT_JSONRPC},
 }

--- a/api/httpjson/RPCserver.go
+++ b/api/httpjson/RPCserver.go
@@ -108,6 +108,19 @@ func (s *RPCServer) Handle(w http.ResponseWriter, r *http.Request) {
 			w.Write(data)
 			return
 		}
+		// if params["RemoteAddr"] set but empty, used request.RemoteAddr
+		if addr, ok := params["RemoteAddr"]; ok {
+			switch addr.(type) {
+			case []byte, string:
+				if len(addr.(string)) == 0 { // empty string
+					params["RemoteAddr"] = r.RemoteAddr
+				}
+			case bool: // save remoteAddr whatever true or false
+				params["RemoteAddr"] = r.RemoteAddr
+			default:
+				log.Warningf("RemoteAddr unsupport type for %v", addr)
+			}
+		}
 
 		//get the corresponding function
 		function, ok := s.mainMux.m[method]

--- a/api/httpjson/client/client.go
+++ b/api/httpjson/client/client.go
@@ -77,3 +77,28 @@ func FindSuccessorAddrs(remote string, key []byte) ([]string, error) {
 
 	return ret.Result, nil
 }
+
+func GetMyExtIP(remote string, ip []byte) (string, error) {
+	resp, err := Call(remote, "getmyextip", 0, map[string]interface{}{
+		"RemoteAddr": ip,
+	})
+	if err != nil {
+		return "", err
+	}
+	log.Printf("GetMyExtIP got resp: %v from %s\n", string(resp), remote)
+
+	var ret struct {
+		Result struct{ RemoteAddr string } `json:"result"`
+		Err    map[string]interface{}      `json:"error"`
+	}
+	if err := json.Unmarshal(resp, &ret); err != nil {
+		log.Println(err)
+		return "", err
+	}
+	if len(ret.Err) != 0 { // resp.error NOT empty
+		return "", fmt.Errorf("GetMyExtIP(%s) resp error: %v", remote, string(resp))
+	}
+	log.Printf("From %s got myself ExtIP: %s\n", remote, string(resp))
+
+	return ret.Result.RemoteAddr, nil
+}

--- a/nknd.go
+++ b/nknd.go
@@ -103,6 +103,22 @@ func JoinNet(nn *nnet.NNet) error {
 	return errors.New("Failed to join the network.")
 }
 
+// AskMyID request to seeds randomly, in order to obtain self's externIP and corresponding chordID
+func AskMyID(seeds []string) (string, error) {
+	rand.Shuffle(len(seeds), func(i int, j int) {
+		seeds[i], seeds[j] = seeds[j], seeds[i]
+	})
+
+	for _, seed := range seeds {
+		addr, err := client.GetMyExtIP(seed, []byte{})
+		if err == nil {
+			return addr, err
+		}
+		log.Warningf("Ask my ID from %s met error: %v", seed, err)
+	}
+	return "", errors.New("Tried all seeds but can't got my external IP and nknID")
+}
+
 func nknMain(c *cli.Context) error {
 	log.Info("Node version: ", config.Version)
 	signalChan := make(chan os.Signal, 1)
@@ -114,6 +130,15 @@ func nknMain(c *cli.Context) error {
 	log.Log.SetDebugLevel(config.Parameters.LogLevel) // Update LogLevel after config.json loaded
 
 	defer config.Parameters.CleanPortMapping()
+
+	if config.Parameters.Hostname == "" {
+		log.Info("Getting my IP address...")
+		extIP, err := AskMyID(config.Parameters.SeedList)
+		if err != nil {
+			return err
+		}
+		config.Parameters.Hostname = extIP
+	}
 
 	// Get local account
 	wallet := vault.GetWallet()
@@ -139,7 +164,6 @@ func nknMain(c *cli.Context) error {
 	}
 
 	id := address.GenChordID(fmt.Sprintf("%s:%d", config.Parameters.Hostname, config.Parameters.NodePort))
-
 	nn, err := nnet.NewNNet(id, conf)
 	if err != nil {
 		return err
@@ -168,7 +192,7 @@ func nknMain(c *cli.Context) error {
 
 	err = por.InitPorServer(account, id)
 	if err != nil {
-		return errors.New("PorServer initialization error")
+		return fmt.Errorf("PorServer initialization error with: %v", err)
 	}
 
 	localNode, err := node.NewLocalNode(wallet, nn)

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -15,7 +15,6 @@ import (
 	gonat "github.com/nknorg/go-nat"
 	"github.com/nknorg/go-portscanner"
 	"github.com/nknorg/nnet/transport"
-	"github.com/rdegges/go-ipify"
 )
 
 const (
@@ -117,27 +116,6 @@ func Init() error {
 	if err := Parameters.SetupPortMapping(); err != nil {
 		log.Printf("Error adding port mapping. If this problem persists, you can use --no-nat flag to bypass automatic port forwarding and set it up yourself.")
 		return err
-	}
-
-	if Parameters.Hostname == "" {
-		log.Println("Getting my IP address...")
-		ip, err := ipify.GetIp()
-		if err != nil {
-			return err
-		}
-		log.Printf("My IP address is %s", ip)
-
-		Parameters.Hostname = ip
-
-		// if !SkipCheckPort {
-		// 	ok, err := Parameters.CheckPorts(ip)
-		// 	if err != nil {
-		// 		return err
-		// 	}
-		// 	if !ok {
-		// 		return errors.New("Some ports are not open. Please make sure you set up port forwarding or firewall correctly")
-		// 	}
-		// }
 	}
 
 	err := check(Parameters)


### PR DESCRIPTION
### Proposed changes in this pull request
Currently, nknd was informed self external IP by centralized service —— ipify.
For more decentralized, query self external IP & chordID via RPC to seedList, instead of ipify.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [x] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
