### PR TITLE
add commands to query the balance and nonce of a address

### DIFF
--- a/cli/info/info.go
+++ b/cli/info/info.go
@@ -25,6 +25,8 @@ func infoAction(c *cli.Context) (err error) {
 	ring := c.Bool("ring")
 	state := c.Bool("state")
 	version := c.Bool("nodeversion")
+	balance := c.String("balance")
+	nonce := c.String("nonce")
 
 	var resp []byte
 	var output [][]byte
@@ -118,6 +120,25 @@ func infoAction(c *cli.Context) (err error) {
 		output = append(output, resp)
 
 	}
+
+	if balance != "" {
+		resp, err := client.Call(Address(), "getbalancebyaddr", 0, map[string]interface{}{"address": balance})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+		output = append(output, resp)
+	}
+
+	if nonce != "" {
+		resp, err := client.Call(Address(), "getnoncebyaddr", 0, map[string]interface{}{"address": nonce})
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+		output = append(output, resp)
+	}
+
 	for _, v := range output {
 		FormatOutput(v)
 	}
@@ -172,6 +193,14 @@ func NewCommand() *cli.Command {
 			cli.BoolFlag{
 				Name:  "nodeversion, v",
 				Usage: "version of connected remote node",
+			},
+			cli.StringFlag{
+				Name:  "balance",
+				Usage: "balance of a address",
+			},
+			cli.StringFlag{
+				Name:  "nonce",
+				Usage: "nonce of a address",
 			},
 		},
 		Action: infoAction,


### PR DESCRIPTION
add two commands to cli:
1) nknc info --balance <address>
2) nknc info --nonce   <address>
to query the balance and the nonce of a address.

Signed-off-by: NoelBright <noel.n.bright@gmail.com>

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
