### PR TITLE
fixbug: wallet and node use different crypto algorithm

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -144,6 +144,23 @@ func (e *PubKey) Deserialize(r io.Reader) error {
 	return nil
 }
 
+func CheckPrivateKey(privkey []byte) error {
+	switch AlgChoice {
+	case P256R1:
+		if len(privkey) != p256r1.GetPrivateKeySize() {
+			return fmt.Errorf("the length of ECDSA privatekey is not %d", p256r1.GetPrivateKeySize())
+		}
+	case Ed25519:
+		if len(privkey) != ed25519.GetPrivateKeySize() {
+			return fmt.Errorf("the length of Ed25519 privatekey is not %d", ed25519.GetPrivateKeySize())
+		}
+	default:
+		panic("unsupported algorithm type")
+	}
+
+	return nil
+}
+
 type PubKeySlice []*PubKey
 
 func (p PubKeySlice) Len() int { return len(p) }

--- a/crypto/encode.go
+++ b/crypto/encode.go
@@ -237,13 +237,13 @@ func deCompress(yTilde int, xValue []byte, curve *elliptic.CurveParams) (*PubKey
 }
 
 func DecodePoint(encodeData []byte) (*PubKey, error) {
+	if len(encodeData) == 0 {
+		return nil, errors.New("The encodeData cann't be nil")
+	}
+
 	if AlgChoice == Ed25519 {
 		return &PubKey{X: new(big.Int).SetBytes(encodeData[1:]), Y: big.NewInt(0)}, nil
 	} else {
-		if nil == encodeData {
-			return nil, errors.New("The encodeData cann't be nil")
-		}
-
 		switch encodeData[0] {
 		case 0x00:
 			return &PubKey{nil, nil}, nil

--- a/crypto/p256r1/p256r1.go
+++ b/crypto/p256r1/p256r1.go
@@ -11,6 +11,11 @@ import (
 	"github.com/nknorg/nkn/crypto/util"
 )
 
+const (
+	PrivateKeySize = 32
+	SignatureSize  = 64
+)
+
 func Init(algSet *util.CryptoAlgSet) {
 	algSet.Curve = elliptic.P256()
 	algSet.EccParams = *(algSet.Curve.Params())
@@ -60,4 +65,8 @@ func Verify(algSet *util.CryptoAlgSet, X *big.Int, Y *big.Int, data []byte, r, s
 	} else {
 		return errors.New("[Validation], Verify failed.")
 	}
+}
+
+func GetPrivateKeySize() int {
+	return PrivateKeySize
 }

--- a/vault/wallet.go
+++ b/vault/wallet.go
@@ -123,6 +123,12 @@ func OpenWallet(path string, password []byte) (*WalletImpl, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if err := crypto.CheckPrivateKey(privateKey); err != nil {
+		log.Error("open wallet error", err)
+		os.Exit(1)
+	}
+
 	account, err := NewAccountWithPrivatekey(privateKey)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When the crypto algorithm used by node is different from wallet,
it will exit and print error log.
When the node is being connectted by an node with v0.8 verion, it
will reject this connection.

Signed-off-by: NoelBright <noel.n.bright@gmail.com>

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
