### PR TITLE
Change wallet address prefix for better fool proof

### DIFF
--- a/block/block.go
+++ b/block/block.go
@@ -193,7 +193,7 @@ func GenesisBlockInit() (*Block, error) {
 		},
 	}
 
-	rewardAddress, _ := ToScriptHash("NcX9BWx5uxsevCZ2MUEbBJGoYGSNCuJJpf")
+	rewardAddress, _ := ToScriptHash("NKNU6H1TEckb3yMaSpmyyAbShh7g7GL7xipJ")
 	payload := NewCoinbase(EmptyUint160, rewardAddress, Fixed64(config.DefaultMiningReward*StorageFactor))
 	pl, err := Pack(CoinbaseType, payload)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: gdmmx <gdmmx@163.com>

### Proposed changes in this pull request
Previously, NKN wallet address start with 'N'.
> e.g. "Nxxxxxxxxxxxx"

For better fool proof design, changed to start with "NKN".
> e.g. "NKNxxxxxxxxxxxx"

```diff
- CAUTION:
- This PR is part of RPC incompatible with previous version.
+ But it is compatible for consensus and ChainDB.
```


### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [x] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
