### PR TITLE
Bugfix: Genesis BlockHash different after wallet addr changed

### DIFF
--- a/common/uint160.go
+++ b/common/uint160.go
@@ -88,9 +88,9 @@ func (f *Uint160) Deserialize(r io.Reader) error {
 
 func IsValidHexAddr(s []byte) bool {
 	if len(s) == HEXADDRLEN && new(big.Int).SetBytes(s[:PREFIXLEN]).Uint64() == FOOLPROOFPREFIX {
-		sha := sha256.Sum256(s[:1+UINT160SIZE])
+		sha := sha256.Sum256(s[:PREFIXLEN+UINT160SIZE])
 		chkSum := sha256.Sum256(sha[:])
-		return bytes.Compare(s[1+UINT160SIZE:], chkSum[:SHA256CHKSUM]) == 0
+		return bytes.Compare(s[PREFIXLEN+UINT160SIZE:], chkSum[:SHA256CHKSUM]) == 0
 	}
 	return false
 }
@@ -139,7 +139,7 @@ func ToScriptHash(address string) (Uint160, error) {
 		return EmptyUint160, fmt.Errorf("address[%s] decode %x not a valid address", address, hex)
 	}
 
-	return Uint160ParseFromBytes(hex[1 : 1+UINT160SIZE])
+	return Uint160ParseFromBytes(hex[PREFIXLEN : PREFIXLEN+UINT160SIZE])
 }
 
 func (u *Uint160) SetBytes(b []byte) {


### PR DESCRIPTION
Signed-off-by: gdmmx <gdmmx@163.com>

### Proposed changes in this pull request
Genesis BlockHash different after wallet address changed.
Fix it.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
