### PR TITLE
stop dumping informations from transaction pool

### DIFF
--- a/chain/pool/txlist.go
+++ b/chain/pool/txlist.go
@@ -275,20 +275,20 @@ func (nst *NonceSortedTxs) Dump() {
 	nst.mu.RLock()
 	defer nst.mu.RUnlock()
 	addr, _ := nst.account.ToAddress()
-	log.Error("account:", addr)
-	log.Error("txs:", len(nst.txs))
+	log.Info("account:", addr)
+	log.Info("txs:", len(nst.txs))
 	for h, tx := range nst.txs {
-		log.Error(h.ToHexString(), ":", tx.UnsignedTx.Nonce)
+		log.Info(h.ToHexString(), ":", tx.UnsignedTx.Nonce)
 	}
-	log.Error("idx:", len(nst.idx))
+	log.Info("idx:", len(nst.idx))
 	for _, h := range nst.idx {
-		log.Error(h.ToHexString())
+		log.Info(h.ToHexString())
 	}
-	log.Error("orphans:", len(nst.orphans))
+	log.Info("orphans:", len(nst.orphans))
 	for h, tx := range nst.orphans {
-		log.Error(h.ToHexString(), ":", tx.UnsignedTx.Nonce)
+		log.Info(h.ToHexString(), ":", tx.UnsignedTx.Nonce)
 	}
-	log.Error("cap:", nst.cap)
+	log.Info("cap:", nst.cap)
 }
 
 //type FeeSortedTxns []*Transaction

--- a/chain/pool/txpool.go
+++ b/chain/pool/txpool.go
@@ -72,7 +72,7 @@ func (tp *TxnPool) AppendTxnPool(txn *Transaction) error {
 		list.CleanOrphans(nil)
 	}
 
-	tp.Dump()
+	//tp.Dump()
 
 	return nil
 }
@@ -236,7 +236,7 @@ func (tp *TxnPool) GetTxnByCount(num int) (map[common.Uint256]*Transaction, erro
 		txmap[tx.Hash()] = tx
 	}
 
-	tp.Dump()
+	//tp.Dump()
 	return txmap, nil
 }
 
@@ -250,7 +250,7 @@ func (tp *TxnPool) Dump() {
 
 	log.Error("SigChainTxs:")
 	for h, _ := range tp.SigChainTxs {
-		log.Error(h.ToHexString())
+		log.Info(h.ToHexString())
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: NoelBright <noel.n.bright@gmail.com>

### Proposed changes in this pull request
Stop dumping informations from transaction pool. And modify the log level of Dump().

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
