### PR TITLE
public key EncodePoint incorrectly

### DIFF
--- a/crypto/encode.go
+++ b/crypto/encode.go
@@ -277,7 +277,8 @@ func DecodePoint(encodeData []byte) (*PubKey, error) {
 func (e *PubKey) EncodePoint(isCommpressed bool) ([]byte, error) {
 	if AlgChoice == Ed25519 {
 		encodedData := make([]byte, COMPRESSEDLEN)
-		copy(encodedData[1:], e.X.Bytes())
+		xBytes := e.X.Bytes()
+		copy(encodedData[COMPRESSEDLEN-len(xBytes):COMPRESSEDLEN], xBytes)
 		encodedData[0] = 0x04
 		return encodedData, nil
 	} else {


### PR DESCRIPTION
### Proposed changes in this pull request

When the first byte of public key if zero. the EncodePoint will
get a wrong output. In this case, we add a prefix 0 in the front
of encoded public key manually.

Signed-off-by: NoelBright <noel.n.bright@gmail.com>

### Type (put an `x` where ever applicable)
- [X] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [X] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [ ] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
