### PR TITLE
Add sigChain parser utility and fix logLevel bug

### DIFF
--- a/common/uint160.go
+++ b/common/uint160.go
@@ -142,11 +142,12 @@ func ToScriptHash(address string) (Uint160, error) {
 	return Uint160ParseFromBytes(hex[PREFIXLEN : PREFIXLEN+UINT160SIZE])
 }
 
-func (u *Uint160) SetBytes(b []byte) {
+func (u *Uint160) SetBytes(b []byte) *Uint160 {
 	if len(b) > len(u) {
 		b = b[len(b)-UINT160SIZE:]
 	}
 	copy(u[UINT160SIZE-len(b):], b)
+	return u
 }
 
 func BytesToUint160(b []byte) Uint160 {

--- a/util/bytes2sigchain.go
+++ b/util/bytes2sigchain.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/nknorg/nkn/pb"
+)
+
+// Base64ToHex convert base64 string input to hex string output
+func Base64ToHex(in []byte) (out []byte, err error) { // input format should be ':"balabala..."'
+	const prefix, suffix = ":\"", "\""
+	start, end := len(prefix), len(in)-len(suffix) // b64Str len not contain :" prefix and " suffix
+
+	// Decode Base64 string to bin
+	bin := make([]byte, base64.StdEncoding.DecodedLen(end-start))
+	n, err := base64.StdEncoding.Decode(bin, in[start:end])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "base64 decode %s met erro %v\n", in[start:end], err)
+		return []byte{}, err
+	}
+
+	// Encode bin to hex string
+	hexStr := make([]byte, 2*len(bin[:n]))
+	hex.Encode(hexStr, bin[:n])
+
+	// return strcat
+	out = append(out, prefix...)       // append :" prefix
+	out = append(out, hexStr...)       // append hexStr
+	return append(out, suffix...), err // append " suffix
+}
+
+// Base64Handler will find all matching with pattern in input, and replace them with hex string
+func Base64Handler(pattern *regexp.Regexp, out io.Writer, in []byte) {
+	seek := 0                                        // init cursor
+	for _, s := range pattern.FindAllIndex(in, -1) { // foreach matching
+		out.Write(in[seek:s[0]]) // copy string between two matching
+
+		// append hex string if convert successful or append orig in failed
+		if str, err := Base64ToHex(in[s[0]:s[1]]); err == nil {
+			out.Write(str)
+		} else {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			out.Write(in[s[0]:s[1]])
+		}
+		seek = s[1] // update cursor
+	}
+
+	out.Write(in[seek:]) // copy remaining string
+}
+
+func main() {
+	// regexp pattern `:"RFC4648"`
+	re := regexp.MustCompile(":\"(?:[a-zA-Z0-9+\\/]{4})*(?:|(?:[a-zA-Z0-9+\\/]{3}=)|(?:[a-zA-Z0-9+\\/]{2}==)|(?:[a-zA-Z0-9+\\/]{1}===))\"")
+	for {
+		l, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		switch err {
+		case nil: // readLine successful from stdin
+		case io.EOF:
+			return
+		default:
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			continue // read current line error, skip & next
+		}
+
+		var buf, jStr []byte
+		if buf, err = hex.DecodeString(strings.TrimRight(l, "\n")); err == nil { // hexStr to bin
+			commitTxn := &pb.Commit{}
+			if err = commitTxn.Unmarshal(buf); err == nil { // bin to pb struct of commitType txn
+				// submitter, _ := new(common.Uint160).SetBytes(commitTxn.Submitter).ToAddress()
+				sc := &pb.SigChain{}
+				if err = sc.Unmarshal(commitTxn.SigChain); err == nil { // bin to pb struct of sigChain
+					js := map[string]interface{}{"SigChain": sc, "Submitter": commitTxn.Submitter}
+					if jStr, err = json.Marshal(js); err == nil { // to json string
+						Base64Handler(re, os.Stdout, jStr) // replace all in jStr to stdout
+						os.Stdout.WriteString("\n")
+						continue
+					}
+				}
+			}
+		}
+		fmt.Fprintf(os.Stderr, "%v\n", err) // any error from above
+	}
+}

--- a/util/log/log.go
+++ b/util/log/log.go
@@ -100,7 +100,7 @@ func New(out io.Writer, prefix string, flag, level int, file *os.File) *Logger {
 }
 
 func (l *Logger) SetDebugLevel(level int) error {
-	if level > maxLevelLog || level < 0 {
+	if level >= maxLevelLog || level < 0 {
 		return errors.New("Invalid Debug Level")
 	}
 


### PR DESCRIPTION
### Proposed changes in this pull request
Add v0.9 utility for parse sigChain from hex byte stream

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
