### PR TITLE
Upgrade TestNet/Protocol/DB ver for divide up previous incompatible v09 testnet

### DIFF
--- a/nknd.go
+++ b/nknd.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	TestNetVersionNum = 1
+	TestNetVersionNum = 2
 )
 
 var (

--- a/node/localnode.go
+++ b/node/localnode.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	protocolVersion              = 21
-	minCompatibleProtocolVersion = 21
-	maxCompatibleProtocolVersion = 25
+	protocolVersion              = 26
+	minCompatibleProtocolVersion = 26
+	maxCompatibleProtocolVersion = 30
 )
 
 type LocalNode struct {

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -32,7 +32,7 @@ const (
 	MaxRollbackBlocks            = 1
 	SigChainPropogationTime      = 1
 	EncryptAlg                   = "Ed25519"
-	DBVersion                    = 0x04
+	DBVersion                    = 0x05
 	InitialIssueAddress          = "NKNQ83xc8zQNEE6WBDKm7tZrLwoMwAq4c4jo"
 	InitialIssueAmount           = 700000000 * common.StorageFactor
 	TotalMiningRewards           = 300000000 * common.StorageFactor


### PR DESCRIPTION

Signed-off-by: gdmmx <gdmmx@nkn.org>

### Proposed changes in this pull request
Upgrade TestNet/Protocol/DB version for divide up previous incompatible v09 testnet

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [x] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
