### PR TITLE
Prevent sigchain being added to txn pool and allow it to be included in history blocks

### DIFF
--- a/chain/blockValidator.go
+++ b/chain/blockValidator.go
@@ -284,40 +284,37 @@ func TimestampCheck(timestamp int64) error {
 }
 
 func NextBlockProposerCheck(block *Block) error {
-	winnerHash, winnerType, err := GetNextMiningSigChainTxnHash(block.Header.UnsignedHeader.Height)
+	expectedWinnerHash, expectedWinnerType, err := GetNextMiningSigChainTxnHash(block.Header.UnsignedHeader.Height)
 	if err != nil {
 		return err
 	}
 
-	bwhash, _ := Uint256ParseFromBytes(block.Header.UnsignedHeader.WinnerHash)
-	if winnerHash == EmptyUint256 && bwhash != EmptyUint256 {
-		for _, txn := range block.Transactions {
-			if txn.Hash() == bwhash {
-				_, err = por.NewPorPackage(txn)
-				return err
-			}
-		}
-		return fmt.Errorf("mining sigchain txn %s not found in block", bwhash)
+	winnerType := block.Header.UnsignedHeader.WinnerType
+	winnerHash, err := Uint256ParseFromBytes(block.Header.UnsignedHeader.WinnerHash)
+	if err != nil {
+		return err
 	}
 
-	if winnerType != block.Header.UnsignedHeader.WinnerType {
-		return fmt.Errorf("Winner type should be %v instead of %v", winnerType, block.Header.UnsignedHeader.WinnerType)
+	if winnerType != expectedWinnerType {
+		return fmt.Errorf("Winner type should be %v instead of %v", expectedWinnerType, winnerType)
 	}
 
-	if winnerHash != bwhash {
-		return fmt.Errorf("Winner hash should be %s instead of %s", winnerHash.ToHexString(), block.Header.UnsignedHeader.WinnerHash)
+	if winnerHash != expectedWinnerHash {
+		return fmt.Errorf("Winner hash should be %s instead of %s", expectedWinnerHash.ToHexString(), winnerHash)
 	}
 
-	if bwhash != EmptyUint256 {
+	if winnerHash != EmptyUint256 {
 		found := false
 		for _, txn := range block.Transactions {
-			if txn.Hash() == bwhash {
+			if txn.Hash() == winnerHash {
 				found = true
 				break
 			}
 		}
 		if !found {
-			return fmt.Errorf("mining sigchain txn %s not found in block", block.Header.UnsignedHeader.WinnerHash)
+			if _, err := DefaultLedger.Store.GetTransaction(winnerHash); err != nil {
+				return fmt.Errorf("mining sigchain txn %s not found in block", winnerHash)
+			}
 		}
 	}
 

--- a/chain/mining.go
+++ b/chain/mining.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Mining interface {
-	BuildBlock(height uint32, chordID []byte, winningHash common.Uint256, winnerType WinnerType, timestamp int64) (*Block, error)
+	BuildBlock(height uint32, chordID []byte, winnerHash common.Uint256, winnerType WinnerType, timestamp int64) (*Block, error)
 }
 
 type BuiltinMining struct {
@@ -32,7 +32,7 @@ func NewBuiltinMining(account *vault.Account, txnCollector *TxnCollector) *Built
 	}
 }
 
-func (bm *BuiltinMining) BuildBlock(height uint32, chordID []byte, winningHash common.Uint256, winnerType WinnerType, timestamp int64) (*Block, error) {
+func (bm *BuiltinMining) BuildBlock(height uint32, chordID []byte, winnerHash common.Uint256, winnerType WinnerType, timestamp int64) (*Block, error) {
 	var txnList []*Transaction
 	var txnHashList []common.Uint256
 
@@ -47,14 +47,16 @@ func (bm *BuiltinMining) BuildBlock(height uint32, chordID []byte, winningHash c
 	txCount := 1
 
 	if winnerType == TXN_SIGNER {
-		miningSigChainTxn, err := por.GetPorServer().GetMiningSigChainTxn(winningHash)
-		if err != nil {
-			return nil, err
+		if _, err = DefaultLedger.Store.GetTransaction(winnerHash); err != nil {
+			miningSigChainTxn, err := por.GetPorServer().GetMiningSigChainTxn(winnerHash)
+			if err != nil {
+				return nil, err
+			}
+			txnList = append(txnList, miningSigChainTxn)
+			txnHashList = append(txnHashList, miningSigChainTxn.Hash())
+			totalTxsSize = totalTxsSize + miningSigChainTxn.GetSize()
+			txCount++
 		}
-		txnList = append(txnList, miningSigChainTxn)
-		txnHashList = append(txnHashList, miningSigChainTxn.Hash())
-		totalTxsSize = totalTxsSize + miningSigChainTxn.GetSize()
-		txCount++
 	}
 
 	txns, err := bm.txnCollector.Collect()
@@ -103,7 +105,7 @@ func (bm *BuiltinMining) BuildBlock(height uint32, chordID []byte, winningHash c
 				ConsensusData:    rand.Uint64(),
 				TransactionsRoot: txnRoot.ToArray(),
 				StateRoot:        curStateHash.ToArray(),
-				WinnerHash:       winningHash.ToArray(),
+				WinnerHash:       winnerHash.ToArray(),
 				WinnerType:       winnerType,
 				Signer:           encodedPubKey,
 				ChordId:          chordID,

--- a/chain/pool/txpool.go
+++ b/chain/pool/txpool.go
@@ -87,12 +87,12 @@ func (tp *TxnPool) processTx(txn *Transaction) error {
 	hash := txn.Hash()
 	sender, _ := common.ToCodeHash(txn.Programs[0].Code)
 
-	// 1. check if the sender is exsit.
+	// 1. check if the sender exsits.
 	if _, ok := tp.TxLists.Load(sender); !ok {
 		tp.TxLists.LoadOrStore(sender, NewNonceSortedTxs(sender, DefaultCap))
 	}
 
-	// 2. check if the txn is exsit.
+	// 2. check if the txn exsits.
 	v, ok := tp.TxLists.Load(sender)
 	if !ok {
 		return errors.New("get txn list error")
@@ -110,6 +110,9 @@ func (tp *TxnPool) processTx(txn *Transaction) error {
 		return err
 	}
 	switch txn.UnsignedTx.Payload.Type {
+	case pb.CommitType:
+		// sigchain txn should not be added to txn pool
+		return nil
 	case pb.TransferAssetType:
 		ta := pl.(*pb.TransferAsset)
 		amount := chain.DefaultLedger.Store.GetBalance(sender)
@@ -214,7 +217,6 @@ func (tp *TxnPool) processTx(txn *Transaction) error {
 	list.AddOrphanTxn(txn)
 
 	return nil
-
 }
 
 func (tp *TxnPool) GetAllTransactions() map[common.Uint256]*Transaction {
@@ -334,17 +336,6 @@ func (tp *TxnPool) verifyTransactionWithLedger(txn *Transaction) error {
 		return ErrDuplicatedTx
 	}
 
-	// get signature chain from commit transaction then add it to POR server
-	if txn.UnsignedTx.Payload.Type == pb.CommitType {
-		added, err := por.GetPorServer().AddSigChainFromTx(txn, chain.DefaultLedger.Store.GetHeight())
-		if err != nil {
-			return err
-		}
-		if !added {
-			return ErrDuplicatedTx
-		}
-	}
-
 	sender, _ := common.ToCodeHash(txn.Programs[0].Code)
 	nonce := chain.DefaultLedger.Store.GetNonce(sender)
 
@@ -357,6 +348,13 @@ func (tp *TxnPool) verifyTransactionWithLedger(txn *Transaction) error {
 	case pb.CoinbaseType:
 		return ErrTxnType
 	case pb.CommitType:
+		added, err := por.GetPorServer().AddSigChainFromTx(txn, chain.DefaultLedger.Store.GetHeight())
+		if err != nil {
+			return err
+		}
+		if !added {
+			return ErrNonOptimalSigChain
+		}
 	case pb.TransferAssetType:
 		if txn.UnsignedTx.Nonce < nonce {
 			return ErrNonceTooLow


### PR DESCRIPTION
1. Prevent sigchain txn to be added to txn pool
2. Allow mining sigchain to be included in history blocks

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
