### PR TITLE
Use absolute weight instead of relative weight for voting threshold

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -164,11 +164,19 @@ func (consensus *Consensus) loadOrCreateElection(height uint32) (*election.Elect
 		}
 	}
 
+	consensusNeighbors := consensus.localNode.GetNeighbors(func(rn *node.RemoteNode) bool {
+		return rn.GetSyncState() == pb.PersistFinished && height >= rn.GetMinVerifiableHeight()
+	})
+	totalWeight := len(consensusNeighbors)
+	if consensus.localNode.GetSyncState() == pb.PersistFinished {
+		totalWeight++
+	}
+
 	config := &election.Config{
 		Duration:                    electionDuration,
 		MinVotingInterval:           minVotingInterval,
 		ChangeVoteMinRelativeWeight: changeVoteMinRelativeWeight,
-		ConsensusMinRelativeWeight:  consensusMinRelativeWeight,
+		ConsensusMinAbsoluteWeight:  uint32(consensusMinRelativeWeight*float32(totalWeight) + 1),
 	}
 
 	elc, err := election.NewElection(config)


### PR DESCRIPTION
Previously we changed from absolute weight to relative weight for voting success threshold in order to solve the problem of many node restart. Later on when we introduced min verifiable height to solve this problem more robustly, we didn't change the threshold back from relative weight to absolute weight, which may cause the forked region to continue producing blocks.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
