### PR TITLE
improve txpool memory usage

### DIFF
--- a/util/config/config.go
+++ b/util/config/config.go
@@ -50,6 +50,8 @@ const (
 	ProtocolVersion              = 46
 	MinCompatibleProtocolVersion = 46
 	MaxCompatibleProtocolVersion = 50
+	DefaultTxPoolCap             = 32
+	DefaultTxPoolOrphanCap       = 64
 )
 
 var (


### PR DESCRIPTION
limit txnlist.cap to 32 and txnlist.orphanCap to 64.

Signed-off-by: NoelBright <noel.n.bright@gmail.com>


### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
