### PR TITLE
fixbug: cs.GetCurrentBlockStateRoot return wrong root when height is 0

### DIFF
--- a/chain/blockValidator.go
+++ b/chain/blockValidator.go
@@ -146,7 +146,7 @@ func TransactionCheck(ctx context.Context, block *block.Block) error {
 	}
 
 	//state root check
-	root, err := DefaultLedger.Store.GenerateStateRoot(block, false)
+	root, err := DefaultLedger.Store.GenerateStateRoot(block, true, false)
 	if err != nil {
 		return err
 	}

--- a/chain/blockchain.go
+++ b/chain/blockchain.go
@@ -33,7 +33,7 @@ func NewBlockchainWithGenesisBlock(store ILedgerStore) (*Blockchain, error) {
 		return nil, err
 	}
 
-	root, err := store.GenerateStateRoot(genesisBlock, false)
+	root, err := store.GenerateStateRoot(genesisBlock, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/chain/db/stateGenerator.go
+++ b/chain/db/stateGenerator.go
@@ -98,16 +98,20 @@ func (cs *ChainStore) spendTransaction(states *StateDB, txn *transaction.Transac
 	return nil
 }
 
-func (cs *ChainStore) GenerateStateRoot(b *block.Block, needBeCommitted bool) (Uint256, error) {
-	_, root, err := cs.generateStateRoot(b, needBeCommitted)
+func (cs *ChainStore) GenerateStateRoot(b *block.Block, genesisBlockInitialized, needBeCommitted bool) (Uint256, error) {
+	_, root, err := cs.generateStateRoot(b, genesisBlockInitialized, needBeCommitted)
 
 	return root, err
 }
 
-func (cs *ChainStore) generateStateRoot(b *block.Block, needBeCommitted bool) (*StateDB, Uint256, error) {
-	stateRoot, err := cs.GetCurrentBlockStateRoot()
-	if err != nil {
-		return nil, EmptyUint256, err
+func (cs *ChainStore) generateStateRoot(b *block.Block, genesisBlockInitialized, needBeCommitted bool) (*StateDB, Uint256, error) {
+	stateRoot := EmptyUint256
+	if genesisBlockInitialized {
+		var err error
+		stateRoot, err = cs.GetCurrentBlockStateRoot()
+		if err != nil {
+			return nil, EmptyUint256, err
+		}
 	}
 	states, err := NewStateDB(stateRoot, NewTrieStore(cs.GetDatabase()))
 	if err != nil {

--- a/chain/db/store.go
+++ b/chain/db/store.go
@@ -325,7 +325,7 @@ func (cs *ChainStore) persist(b *block.Block) error {
 	}
 
 	//StateRoot
-	states, root, err := cs.generateStateRoot(b, true)
+	states, root, err := cs.generateStateRoot(b, b.Header.UnsignedHeader.Height != 0, true)
 	if err != nil {
 		return err
 	}
@@ -464,10 +464,6 @@ func (cs *ChainStore) getCurrentBlockHashFromDB() (Uint256, uint32, error) {
 }
 
 func (cs *ChainStore) GetCurrentBlockStateRoot() (Uint256, error) {
-	if cs.currentBlockHeight == 0 {
-		return EmptyUint256, nil
-	}
-
 	currentState, err := cs.st.Get(currentStateTrie())
 	if err != nil {
 		return EmptyUint256, err

--- a/chain/ledgerStore.go
+++ b/chain/ledgerStore.go
@@ -41,6 +41,6 @@ type ILedgerStore interface {
 	IsTxHashDuplicate(txhash Uint256) bool
 	IsBlockInStore(hash Uint256) bool
 	Rollback(b *block.Block) error
-	GenerateStateRoot(b *block.Block, needBeCommitted bool) (Uint256, error)
+	GenerateStateRoot(b *block.Block, genesisBlockInitialized, needBeCommitted bool) (Uint256, error)
 	Close()
 }

--- a/chain/mining.go
+++ b/chain/mining.go
@@ -140,7 +140,7 @@ func (bm *BuiltinMining) BuildBlock(ctx context.Context, height uint32, chordID 
 		Transactions: txnList,
 	}
 
-	curStateHash, err := DefaultLedger.Store.GenerateStateRoot(block, false)
+	curStateHash, err := DefaultLedger.Store.GenerateStateRoot(block, true, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: NoelBright <noel.n.bright@gmail.com>

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

