### PR TITLE
Add soft timestamp check and http client timeout

### DIFF
--- a/chain/db/stateGenerator.go
+++ b/chain/db/stateGenerator.go
@@ -7,8 +7,8 @@ import (
 	"github.com/nknorg/nkn/pb"
 	"github.com/nknorg/nkn/transaction"
 	"github.com/nknorg/nkn/util/config"
+	"github.com/nknorg/nkn/util/log"
 	"github.com/nknorg/nkn/vm/contract"
-	"github.com/nknorg/nnet/log"
 )
 
 func (cs *ChainStore) spendTransaction(states *StateDB, txn *transaction.Transaction, totalFee Fixed64, genesis bool) error {


### PR DESCRIPTION
* Hard timestamp check is less strict, but will stop proposal propagation; soft timestamp check is more strict, but will only affect initial vote.
* Add http client timeout

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
