### PR TITLE
fix validation when adding tx to pool

### DIFF
--- a/chain/blockValidator.go
+++ b/chain/blockValidator.go
@@ -123,8 +123,10 @@ func TransactionCheck(ctx context.Context, block *block.Block) error {
 			return fmt.Errorf("transaction sanity check failed: %v", err)
 		}
 		if err := bvs.VerifyTransactionWithBlock(txn, block.Header); err != nil {
+			bvs.Reset()
 			return fmt.Errorf("transaction block check failed: %v", err)
 		}
+		bvs.Commit()
 		if err := VerifyTransactionWithLedger(txn, block.Header); err != nil {
 			return fmt.Errorf("transaction history check failed: %v", err)
 		}


### PR DESCRIPTION
### Proposed changes in this pull request
1. don't change block validation state until we're sure there is no errors
2. apply validation to nano pays too
3. add tx to tx maps when replacing old tx (remove old tx from maps too)
4. clean old tx from block validation state when replacing

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
