### PR TITLE
verify tx with ledger when proposing a block

### DIFF
--- a/chain/blockValidator.go
+++ b/chain/blockValidator.go
@@ -121,7 +121,7 @@ func TransactionCheck(ctx context.Context, block *block.Block) error {
 		if err := VerifyTransaction(txn); err != nil {
 			return fmt.Errorf("transaction sanity check failed: %v", err)
 		}
-		if err := bvs.VerifyTransactionWithBlock(txn, block.Header); err != nil {
+		if err := bvs.VerifyTransactionWithBlock(txn, block.Header.UnsignedHeader.Height); err != nil {
 			bvs.Reset()
 			return fmt.Errorf("transaction block check failed: %v", err)
 		}

--- a/chain/pool/txpool.go
+++ b/chain/pool/txpool.go
@@ -110,7 +110,7 @@ func (tp *TxnPool) processTx(txn *transaction.Transaction) error {
 	case pb.NANO_PAY_TYPE:
 		tp.blockValidationState.Lock()
 		defer tp.blockValidationState.Unlock()
-		if err := tp.blockValidationState.VerifyTransactionWithBlock(txn, nil); err != nil {
+		if err := tp.blockValidationState.VerifyTransactionWithBlock(txn, 0); err != nil {
 			tp.blockValidationState.Reset()
 			return err
 		}
@@ -124,7 +124,7 @@ func (tp *TxnPool) processTx(txn *transaction.Transaction) error {
 			if err := tp.CleanBlockValidationState([]*transaction.Transaction{oldTxn}); err != nil {
 				return err
 			}
-			if err := tp.blockValidationState.VerifyTransactionWithBlock(txn, nil); err != nil {
+			if err := tp.blockValidationState.VerifyTransactionWithBlock(txn, 0); err != nil {
 				tp.blockValidationState.Reset()
 				return err
 			}
@@ -154,7 +154,7 @@ func (tp *TxnPool) processTx(txn *transaction.Transaction) error {
 
 			tp.blockValidationState.Lock()
 			defer tp.blockValidationState.Unlock()
-			if err := tp.blockValidationState.VerifyTransactionWithBlock(txn, nil); err != nil {
+			if err := tp.blockValidationState.VerifyTransactionWithBlock(txn, 0); err != nil {
 				tp.blockValidationState.Reset()
 				return err
 			}


### PR DESCRIPTION
### Proposed changes in this pull request
There is times when tx (already invalid) getting added to a proposed block. Block proposer should verify such txs and don't add them to the block.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
