### PR TITLE
Reduce mining reward to 5 in testnet

### DIFF
--- a/net/node/localnode.go
+++ b/net/node/localnode.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	protocolVersion              = 11
-	minCompatibleProtocolVersion = 11
-	maxCompatibleProtocolVersion = 20
+	protocolVersion              = 21
+	minCompatibleProtocolVersion = 21
+	maxCompatibleProtocolVersion = 30
 )
 
 type LocalNode struct {

--- a/nknd.go
+++ b/nknd.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	TestNetVersionNum = 14
+	TestNetVersionNum = 15
 )
 
 var (

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -25,7 +25,7 @@ const (
 	MaxNumTxnPerBlock   = 4096
 	ConsensusDuration   = 20 * time.Second
 	ConsensusTimeout    = time.Minute
-	DefaultMiningReward = 15
+	DefaultMiningReward = 5
 	MinNumSuccessors    = 8
 	NodeIDBytes         = 32
 	MaxRollbackBlocks   = 50


### PR DESCRIPTION
Reduce mining reward to 5 since mainnet is launched

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [x] Feature (Breaking change)
- [ ] Documentation Improvement
