### PR TITLE
Allow history block to contain register name txn

### DIFF
--- a/chain/txValidator.go
+++ b/chain/txValidator.go
@@ -130,14 +130,15 @@ func CheckTransactionPayload(txn *transaction.Transaction) error {
 		}
 	case pb.SIG_CHAIN_TXN_TYPE:
 	case pb.REGISTER_NAME_TYPE:
-		pld := payload.(*pb.RegisterName)
-		match, err := regexp.MatchString("(^[A-Za-z][A-Za-z0-9-_.+]{2,254}$)", pld.Name)
-		if err != nil {
-			return err
-		}
-		if !match {
-			return fmt.Errorf("name %s should start with a letter, contain A-Za-z0-9-_.+ and have length 3-255", pld.Name)
-		}
+		return errors.New("Register name transaction is not supported yet")
+		// pld := payload.(*pb.RegisterName)
+		// match, err := regexp.MatchString("(^[A-Za-z][A-Za-z0-9-_.+]{2,254}$)", pld.Name)
+		// if err != nil {
+		// 	return err
+		// }
+		// if !match {
+		// 	return fmt.Errorf("name %s should start with a letter, contain A-Za-z0-9-_.+ and have length 3-255", pld.Name)
+		// }
 	case pb.DELETE_NAME_TYPE:
 	case pb.SUBSCRIBE_TYPE:
 		pld := payload.(*pb.Subscribe)

--- a/transaction/payload.go
+++ b/transaction/payload.go
@@ -35,8 +35,8 @@ func Unpack(payload *pb.Payload) (IPayload, error) {
 		pl = new(pb.TransferAsset)
 	case pb.SIG_CHAIN_TXN_TYPE:
 		pl = new(pb.SigChainTxn)
-	// case pb.REGISTER_NAME_TYPE:
-	// 	pl = new(pb.RegisterName)
+	case pb.REGISTER_NAME_TYPE:
+		pl = new(pb.RegisterName)
 	case pb.DELETE_NAME_TYPE:
 		pl = new(pb.DeleteName)
 	case pb.SUBSCRIBE_TYPE:


### PR DESCRIPTION
Allow history block to contain register name txn but not accepting new ones

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
