### PR TITLE
Fix AssembleClientAddress not omitting dot when identifier is empty

### DIFF
--- a/util/address/address.go
+++ b/util/address/address.go
@@ -70,7 +70,11 @@ func ParseClientAddress(addrStr string) ([]byte, []byte, string, error) {
 // AssembleClientAddress returns the client address string from identifier and
 // pubkey
 func AssembleClientAddress(identifier string, pubkey []byte) string {
-	return identifier + "." + hex.EncodeToString(pubkey)
+	addr := hex.EncodeToString(pubkey)
+	if len(identifier) > 0 {
+		addr = identifier + "." + addr
+	}
+	return addr
 }
 
 // ShouldRejectAddr returns if remoteAddr should be rejected by localAddr


### PR DESCRIPTION
Fix AssembleClientAddress not omitting dot when identifier is empty to follow our client address scheme.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
