### PR TITLE
Add -p pretty print for nknc -b, -t, --height

### DIFF
--- a/cli/info/info.go
+++ b/cli/info/info.go
@@ -28,6 +28,7 @@ func infoAction(c *cli.Context) (err error) {
 	balance := c.String("balance")
 	nonce := c.String("nonce")
 	id := c.String("id")
+	pretty := c.Bool("pretty")
 
 	var resp []byte
 	var output [][]byte
@@ -37,6 +38,13 @@ func infoAction(c *cli.Context) (err error) {
 			fmt.Fprintln(os.Stderr, err)
 			return err
 		}
+		if pretty {
+			if p, err := PrettyPrinter(resp).PrettyBlock(); err == nil {
+				resp = p // replace resp if pretty success
+			} else {
+				fmt.Fprintln(os.Stderr, "Fallback to original resp due to PrettyPrint fail: ", err)
+			}
+		}
 		output = append(output, resp)
 	}
 
@@ -45,6 +53,13 @@ func infoAction(c *cli.Context) (err error) {
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return err
+		}
+		if pretty {
+			if p, err := PrettyPrinter(resp).PrettyBlock(); err == nil {
+				resp = p // replace resp if pretty success
+			} else {
+				fmt.Fprintln(os.Stderr, "Fallback to original resp due to PrettyPrint fail: ", err)
+			}
 		}
 		output = append(output, resp)
 	}
@@ -109,6 +124,13 @@ func infoAction(c *cli.Context) (err error) {
 			fmt.Fprintln(os.Stderr, err)
 			return err
 		}
+		if pretty {
+			if p, err := PrettyPrinter(resp).PrettyTxn(); err == nil {
+				resp = p // replace resp if pretty success
+			} else {
+				fmt.Fprintln(os.Stderr, "Output origin resp due to PrettyPrint fail: ", err)
+			}
+		}
 		output = append(output, resp)
 	}
 
@@ -163,6 +185,10 @@ func NewCommand() *cli.Command {
 		Description: "With nknc info, you could look up blocks, transactions, etc.",
 		ArgsUsage:   "[args]",
 		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "pretty, p",
+				Usage: "pretty print",
+			},
 			cli.StringFlag{
 				Name:  "blockhash, b",
 				Usage: "hash for querying a block",

--- a/cli/info/pretty.go
+++ b/cli/info/pretty.go
@@ -1,0 +1,123 @@
+package info
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/nknorg/nkn/pb"
+)
+
+type PrettyPrinter []byte
+
+func TxnUnmarshal(m map[string]interface{}) (interface{}, error) {
+	typ, ok := m["txType"]
+	if !ok {
+		return nil, fmt.Errorf("No such key [txType]")
+	}
+
+	pbHexStr, ok := m["payloadData"]
+	if !ok {
+		return m, nil
+	}
+	buf, err := hex.DecodeString(pbHexStr.(string))
+
+	switch typ {
+	case pb.PayloadType_name[int32(pb.SIG_CHAIN_TXN_TYPE)]:
+		sigChainTxn := &pb.SigChainTxn{}
+		if err = sigChainTxn.Unmarshal(buf); err == nil { // bin to pb struct of SigChainTxnType txn
+			m["payloadData"] = sigChainTxn.ToMap()
+		}
+	case pb.PayloadType_name[int32(pb.COINBASE_TYPE)]:
+		coinBaseTxn := &pb.Coinbase{}
+		if err = coinBaseTxn.Unmarshal(buf); err == nil { // bin to pb struct of Coinbase txn
+			m["payloadData"] = coinBaseTxn.ToMap()
+		}
+	case pb.PayloadType_name[int32(pb.TRANSFER_ASSET_TYPE)]:
+		trans := &pb.TransferAsset{}
+		if err = trans.Unmarshal(buf); err == nil { // bin to pb struct of Coinbase txn
+			m["payloadData"] = trans.ToMap()
+		}
+	case pb.PayloadType_name[int32(pb.GENERATE_ID_TYPE)]:
+		genID := &pb.GenerateID{}
+		if err = genID.Unmarshal(buf); err == nil { // bin to pb struct of Coinbase txn
+			m["payloadData"] = genID.ToMap()
+		}
+	case pb.PayloadType_name[int32(pb.REGISTER_NAME_TYPE)]:
+		regName := &pb.RegisterName{}
+		if err = regName.Unmarshal(buf); err == nil { // bin to pb struct of Coinbase txn
+			m["payloadData"] = regName.ToMap()
+		}
+	case pb.PayloadType_name[int32(pb.SUBSCRIBE_TYPE)]:
+		sub := &pb.Subscribe{}
+		if err = sub.Unmarshal(buf); err == nil { // bin to pb struct of Coinbase txn
+			m["payloadData"] = sub.ToMap()
+		}
+	case pb.PayloadType_name[int32(pb.NANO_PAY_TYPE)]:
+		pay := &pb.NanoPay{}
+		if err = pay.Unmarshal(buf); err == nil { // bin to pb struct of Coinbase txn
+			m["payloadData"] = pay.ToMap()
+		}
+	case pb.PayloadType_name[int32(pb.TRANSFER_NAME_TYPE)]:
+		fallthrough //TODO
+	case pb.PayloadType_name[int32(pb.DELETE_NAME_TYPE)]:
+		fallthrough //TODO
+	case pb.PayloadType_name[int32(pb.UNSUBSCRIBE_TYPE)]:
+		fallthrough //TODO
+	case pb.PayloadType_name[int32(pb.ISSUE_ASSET_TYPE)]:
+		fallthrough //TODO
+	default:
+		return nil, fmt.Errorf("Unknow txType[%s] for pretty print", typ)
+	}
+
+	return m, nil
+}
+
+func (resp PrettyPrinter) PrettyTxn() ([]byte, error) {
+	m := map[string]interface{}{}
+	err := json.Unmarshal(resp, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	v, ok := m["result"]
+	if !ok {
+		return nil, fmt.Errorf("response No such key [result]")
+	}
+
+	if m["result"], err = TxnUnmarshal(v.(map[string]interface{})); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(m)
+}
+
+func (resp PrettyPrinter) PrettyBlock() ([]byte, error) {
+	m := map[string]interface{}{}
+	err := json.Unmarshal(resp, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	ret, ok := m["result"]
+	if !ok {
+		return nil, fmt.Errorf("response No such key [result]")
+	}
+
+	txns, ok := ret.(map[string]interface{})["transactions"]
+	if !ok {
+		return nil, fmt.Errorf("result No such key [transactions]")
+	}
+
+	lst := make([]interface{}, 0)
+	for _, t := range txns.([]interface{}) {
+		if m, err := TxnUnmarshal(t.(map[string]interface{})); err == nil {
+			lst = append(lst, m)
+		} else {
+			lst = append(lst, t) // append origin txn if TxnUnmarshal fail
+		}
+	}
+	txns = lst
+
+	return json.Marshal(m)
+}

--- a/common/common.go
+++ b/common/common.go
@@ -14,6 +14,12 @@ import (
 
 const MaxUint32 = ^uint32(0)
 
+type HexStr []byte
+
+func (b HexStr) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + hex.EncodeToString(b) + "\""), nil
+}
+
 func ToCodeHash(code []byte) (Uint160, error) {
 	temp := sha256.Sum256(code)
 	md := ripemd160.New()

--- a/common/uint160.go
+++ b/common/uint160.go
@@ -89,6 +89,11 @@ func IsValidHexAddr(s []byte) bool {
 	return false
 }
 
+func (f Uint160) MarshalJSON() ([]byte, error) {
+	str, err := f.ToAddress()
+	return []byte("\"" + str + "\""), err
+}
+
 func (f *Uint160) ToAddress() (string, error) {
 	data := append(big.NewInt(FOOLPROOFPREFIX).Bytes(), f.ToArray()...)
 	temp := sha256.Sum256(data)

--- a/pb/sigchain.go
+++ b/pb/sigchain.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/big"
 
+	"github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/common/serialization"
 	"github.com/nknorg/nkn/crypto"
 	"github.com/nknorg/nkn/util/config"
@@ -368,4 +369,33 @@ func (sc *SigChain) SignatureHash() ([]byte, error) {
 	}
 	signatureHash := ComputeSignatureHash(signature, sc.Length())
 	return signatureHash, nil
+}
+
+func (e *SigChainElem) ToMap() map[string]interface{} {
+	return map[string]interface{}{
+		"id":         common.HexStr(e.Id),
+		"nextPubkey": common.HexStr(e.NextPubkey),
+		"mining":     e.Mining,
+		"signature":  common.HexStr(e.Signature),
+		"sigAlgo":    e.SigAlgo,
+		"vrf":        common.HexStr(e.Vrf),
+		"proof":      common.HexStr(e.Proof),
+	}
+}
+
+func (sc *SigChain) ToMap() map[string]interface{} {
+	elems := make([]interface{}, 0)
+	for _, e := range sc.Elems {
+		elems = append(elems, e.ToMap())
+	}
+	return map[string]interface{}{
+		"nonce":      sc.Nonce,
+		"dataSize":   sc.DataSize,
+		"blockHash":  common.HexStr(sc.BlockHash),
+		"srcId":      common.HexStr(sc.SrcId),
+		"srcPubkey":  common.HexStr(sc.SrcPubkey),
+		"destId":     common.HexStr(sc.DestId),
+		"destPubkey": common.HexStr(sc.DestPubkey),
+		"elems":      elems,
+	}
 }

--- a/pb/transaction.go
+++ b/pb/transaction.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/common/serialization"
 )
 
@@ -70,4 +71,67 @@ func (p *Payload) Deserialize(r io.Reader) error {
 	p.Data = dat
 
 	return nil
+}
+
+func (m *Coinbase) ToMap() map[string]interface{} {
+	return map[string]interface{}{
+		"sender":    common.BytesToUint160(m.Sender),
+		"recipient": common.BytesToUint160(m.Recipient),
+		"amount":    m.Amount,
+	}
+}
+
+func (m *TransferAsset) ToMap() map[string]interface{} {
+	return map[string]interface{}{
+		"sender":    common.BytesToUint160(m.Sender),
+		"recipient": common.BytesToUint160(m.Recipient),
+		"amount":    m.Amount,
+	}
+}
+
+func (m *GenerateID) ToMap() map[string]interface{} {
+	return map[string]interface{}{
+		"publicKey":       common.HexStr(m.PublicKey),
+		"registrationFee": m.RegistrationFee,
+	}
+}
+
+func (m *RegisterName) ToMap() map[string]interface{} {
+	return map[string]interface{}{
+		"registrant": common.BytesToUint160(m.Registrant),
+		"name":       m.Name,
+	}
+}
+
+func (m *Subscribe) ToMap() map[string]interface{} {
+	return map[string]interface{}{
+		"subscriber": common.BytesToUint160(m.Subscriber),
+		"identifier": m.Identifier,
+		"topic":      m.Topic,
+		"bucket":     m.Bucket,
+		"duration":   m.Duration,
+		"meta":       m.Meta,
+	}
+}
+
+func (m *NanoPay) ToMap() map[string]interface{} {
+	return map[string]interface{}{
+		"sender":            common.BytesToUint160(m.Sender),
+		"recipient":         common.BytesToUint160(m.Recipient),
+		"id":                m.Id,
+		"amount":            m.Amount,
+		"txnExpiration":     m.TxnExpiration,
+		"nanoPayExpiration": m.NanoPayExpiration,
+	}
+}
+
+func (m *SigChainTxn) ToMap() map[string]interface{} {
+	sc := &SigChain{}
+	if err := sc.Unmarshal(m.SigChain); err != nil {
+		return map[string]interface{}{}
+	}
+	return map[string]interface{}{
+		"SigChain":  sc.ToMap(),
+		"Submitter": common.BytesToUint160(m.Submitter),
+	}
 }


### PR DESCRIPTION
Signed-off-by: gdmmx <gdmmx@163.com>

### Proposed changes in this pull request
As v1 Mainnet's RPC, the field `payloadData` is protobuf hex bytes in `gettransaction`, `getblock` response. It is not friendly for human.
We should deserialize the protobuf bytes stream to readable output from RPC client side.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [x] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.