### PR TITLE
pubkey2addr utils adapt to v1.0 mainnet

### DIFF
--- a/util/pubkey2addr/pubkey2addr.go
+++ b/util/pubkey2addr/pubkey2addr.go
@@ -17,7 +17,7 @@ func Key2Address(key string) (addr string, err error) {
 
 	if k, err = hex.DecodeString(key); err == nil {
 		if pk, err = crypto.DecodePoint(k); err == nil {
-			if redeemHash, err = program.CreateRedeemHash(pk); err == nil {
+			if redeemHash, err = program.CreateProgramHash(pk); err == nil {
 				return redeemHash.ToAddress()
 			}
 		}


### PR DESCRIPTION
Signed-off-by: gdmmx <gdmmx@163.com>

### Proposed changes in this pull request
Program module's API of v1.0 mainnet had changed. pubkey2addr utils adapt to it.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.