### PR TITLE
reduce fds of leveldb from 500 to 100.

### DIFF
--- a/chain/db/db.go
+++ b/chain/db/db.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"github.com/nknorg/nkn/util/config"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/errors"
 	"github.com/syndtr/goleveldb/leveldb/filter"
@@ -33,8 +34,9 @@ const BITSPERKEY = 10
 func NewLevelDBStore(file string) (*LevelDBStore, error) {
 	// default Options
 	o := opt.Options{
-		NoSync: false,
-		Filter: filter.NewBloomFilter(BITSPERKEY),
+		NoSync:                 false,
+		OpenFilesCacheCapacity: config.Parameters.DBFilesCacheCapacity,
+		Filter:                 filter.NewBloomFilter(BITSPERKEY),
 	}
 
 	db, err := leveldb.OpenFile(file, &o)

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	gonat "github.com/nknorg/go-nat"
-	"github.com/nknorg/go-portscanner"
+	portscanner "github.com/nknorg/go-portscanner"
 	"github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/crypto/ed25519"
 	"github.com/nknorg/nkn/crypto/ed25519/vrf"
@@ -118,6 +118,7 @@ var (
 		ChainDBPath:               "ChainDB",
 		WalletFile:                "wallet.json",
 		MaxGetIDSeeds:             3,
+		DBFilesCacheCapacity:      100,
 	}
 )
 
@@ -160,6 +161,7 @@ type Configuration struct {
 	ChainDBPath               string        `json:"ChainDBPath"`
 	WalletFile                string        `json:"WalletFile"`
 	MaxGetIDSeeds             uint32        `json:"MaxGetIDSeeds"`
+	DBFilesCacheCapacity      int           `json:"DBFilesCacheCapacity"`
 }
 
 func Init() error {


### PR DESCRIPTION
OpenFilesCacheCapacity has a default value 500. So I Override it with
100 in opt.Options of leveldb.

Signed-off-by: NoelBright <noel.n.bright@gmail.com>


### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

