### PR TITLE
Print error and exit instead of panic directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ USE_PROXY=GOPROXY=https://goproxy.io
 GOFMT=go fmt
 VERSION:=$(shell git describe --abbrev=4 --dirty --always --tags)
 Minversion:=$(shell date)
-BUILD_NKND_PARAM=-ldflags "-s -w -X github.com/nknorg/nkn/util/config.Version=$(VERSION)" #-race
+BUILD_NKND_PARAM=-ldflags "-s -w -X github.com/nknorg/nkn/util/config.Version=$(VERSION)"
 BUILD_NKNC_PARAM=-ldflags "-s -w -X github.com/nknorg/nkn/cli/common.Version=$(VERSION)"
 IDENTIFIER=$(GOOS)-$(GOARCH)
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -325,9 +325,8 @@ func (consensus *Consensus) saveAcceptedBlock(electedBlockHash common.Uint256) e
 		prevhash, _ := common.Uint256ParseFromBytes(block.Header.UnsignedHeader.PrevBlockHash)
 		started, err := consensus.localNode.StartSyncing(prevhash, block.Header.UnsignedHeader.Height-1, neighbors)
 		if err != nil {
-			log.Errorf("Error syncing blocks: %v", err)
 			if started {
-				panic(err)
+				panic(fmt.Errorf("Error syncing blocks: %v", err))
 			}
 		}
 		if !started {


### PR DESCRIPTION
The helps prevent the release binary printing system absolute path in panic stacktrace. I've tested and found that existing options to remove it (e.g. GOROOT_FINAL) is not guaranteed to work in all cases and Golang does not provide a way to build bitwise identical binary in different environment yet. So the most robust way for now is to capture panic and print the panic message and then exit instead of panic directly. This should not hide stack trace info as panic msg are almost unique now.

Signed-off-by: Yilun <zyl.skysniper@gmail.com>

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement