### PR TITLE
Drop txn only if txn hash match

### DIFF
--- a/chain/pool/txlist.go
+++ b/chain/pool/txlist.go
@@ -103,20 +103,24 @@ func (nst *NonceSortedTxs) Pop() (*transaction.Transaction, error) {
 	return tx, nil
 }
 
-func (nst *NonceSortedTxs) Drop() (*transaction.Transaction, error) {
+func (nst *NonceSortedTxs) Drop(hashToDrop common.Uint256) (*transaction.Transaction, bool, error) {
 	nst.mu.Lock()
 	defer nst.mu.Unlock()
 
 	if nst.empty() {
-		return nil, ErrNonceSortedTxsEmpty
+		return nil, false, ErrNonceSortedTxsEmpty
 	}
 
 	hash := nst.idx[nst.len()-1]
+	if hashToDrop != common.EmptyUint256 && hash != hashToDrop {
+		return nil, false, nil
+	}
+
 	nst.idx = nst.idx[:nst.len()-1]
 	tx := nst.txs[hash]
 	delete(nst.txs, hash)
 
-	return tx, nil
+	return tx, true, nil
 }
 
 func (nst *NonceSortedTxs) Seek() (*transaction.Transaction, error) {

--- a/nknd.go
+++ b/nknd.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	NetVersionNum = 5 // This is temporary and will be removed soon after mainnet is stabilized
+	NetVersionNum = 6 // This is temporary and will be removed soon after mainnet is stabilized
 )
 
 var (

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -125,7 +125,7 @@ var (
 		NATPortMappingTimeout:     365 * 86400,
 		NumTxnPerBlock:            256,
 		TxPoolPerAccountTxCap:     32,
-		TxPoolTotalTxCap:          1000,
+		TxPoolTotalTxCap:          1024,
 		RegisterIDFee:             0,
 		LogPath:                   "Log",
 		ChainDBPath:               "ChainDB",


### PR DESCRIPTION
This solves the race condition that when a txn is removed from or added to txn pool list during drop loop, a wrong txn might be dropped unexpectedly.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
