### PR TITLE
Improve TxPool memory management and dropping logic

### DIFF
--- a/block/block.go
+++ b/block/block.go
@@ -60,7 +60,7 @@ func (b *Block) Unmarshal(buf []byte) error {
 func (b *Block) GetTxsSize() int {
 	txnSize := 0
 	for _, txn := range b.Transactions {
-		txnSize += txn.GetSize()
+		txnSize += int(txn.GetSize())
 	}
 
 	return txnSize

--- a/chain/db/db.go
+++ b/chain/db/db.go
@@ -35,7 +35,7 @@ func NewLevelDBStore(file string) (*LevelDBStore, error) {
 	// default Options
 	o := opt.Options{
 		NoSync:                 false,
-		OpenFilesCacheCapacity: config.Parameters.DBFilesCacheCapacity,
+		OpenFilesCacheCapacity: int(config.Parameters.DBFilesCacheCapacity),
 		Filter:                 filter.NewBloomFilter(BITSPERKEY),
 	}
 

--- a/chain/pool/txlist.go
+++ b/chain/pool/txlist.go
@@ -103,20 +103,24 @@ func (nst *NonceSortedTxs) Pop() (*transaction.Transaction, error) {
 	return tx, nil
 }
 
-func (nst *NonceSortedTxs) Drop() (*transaction.Transaction, error) {
+func (nst *NonceSortedTxs) Drop(hashToDrop common.Uint256) (*transaction.Transaction, bool, error) {
 	nst.mu.Lock()
 	defer nst.mu.Unlock()
 
 	if nst.empty() {
-		return nil, ErrNonceSortedTxsEmpty
+		return nil, false, ErrNonceSortedTxsEmpty
 	}
 
 	hash := nst.idx[nst.len()-1]
+	if hashToDrop != common.EmptyUint256 && hash != hashToDrop {
+		return nil, false, nil
+	}
+
 	nst.idx = nst.idx[:nst.len()-1]
 	tx := nst.txs[hash]
 	delete(nst.txs, hash)
 
-	return tx, nil
+	return tx, true, nil
 }
 
 func (nst *NonceSortedTxs) Seek() (*transaction.Transaction, error) {

--- a/nknd.go
+++ b/nknd.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	NetVersionNum = 5 // This is temporary and will be removed soon after mainnet is stabilized
+	NetVersionNum = 6 // This is temporary and will be removed soon after mainnet is stabilized
 )
 
 var (

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -18,6 +18,7 @@ import (
 type Transaction struct {
 	*pb.Transaction
 	hash                *Uint256
+	size                uint32
 	isSignatureVerified bool
 }
 
@@ -97,9 +98,12 @@ func (tx *Transaction) DeserializeUnsigned(r io.Reader) error {
 	return nil
 }
 
-func (tx *Transaction) GetSize() int {
-	marshaledTx, _ := tx.Marshal()
-	return len(marshaledTx)
+func (tx *Transaction) GetSize() uint32 {
+	if tx.size == 0 {
+		marshaledTx, _ := tx.Marshal()
+		tx.size = uint32(len(marshaledTx))
+	}
+	return tx.size
 }
 
 func (tx *Transaction) GetProgramHashes() ([]Uint160, error) {

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -125,7 +125,7 @@ var (
 		NATPortMappingTimeout:     365 * 86400,
 		NumTxnPerBlock:            256,
 		TxPoolPerAccountTxCap:     32,
-		TxPoolTotalTxCap:          1000,
+		TxPoolTotalTxCap:          1024,
 		RegisterIDFee:             0,
 		LogPath:                   "Log",
 		ChainDBPath:               "ChainDB",


### PR DESCRIPTION
* Drop txn only if txn hash match to prevent race condition
* Limit txpool memory size and sync blocks memory size
* Implement dropping nanopay txn in txpool

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
