### PR TITLE
Add LowFeeTxnSizePerBlock to control low fee txn size per block

### DIFF
--- a/chain/pool/txpool.go
+++ b/chain/pool/txpool.go
@@ -285,7 +285,7 @@ func (tp *TxnPool) processTx(txn *transaction.Transaction) error {
 		tp.blockValidationState.Commit()
 	default:
 		if oldTxn, err := list.Get(txn.UnsignedTx.Nonce); err == nil {
-			log.Warning("replace old tx")
+			log.Debug("replace old tx")
 			tp.blockValidationState.Lock()
 			defer tp.blockValidationState.Unlock()
 			if err := tp.CleanBlockValidationState([]*transaction.Transaction{oldTxn}); err != nil {

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -138,7 +138,8 @@ var (
 		WalletFile:                "wallet.json",
 		MaxGetIDSeeds:             3,
 		DBFilesCacheCapacity:      100,
-		NumLowFeeTxnPerBlock:      4,
+		NumLowFeeTxnPerBlock:      0,
+		LowFeeTxnSizePerBlock:     4096,
 		MinTxnFee:                 10000000,
 	}
 )
@@ -161,6 +162,7 @@ type Configuration struct {
 	CAPath                    string        `json:"CAPath"`
 	GenesisBlockProposer      string        `json:"GenesisBlockProposer"`
 	NumLowFeeTxnPerBlock      uint32        `json:"NumLowFeeTxnPerBlock"`
+	LowFeeTxnSizePerBlock     uint32        `json:"LowFeeTxnSizePerBlock"` // in bytes
 	MinTxnFee                 int64         `json:"MinTxnFee"`
 	RegisterIDRegFee          int64         `json:"RegisterIDRegFee"`
 	RegisterIDTxnFee          int64         `json:"RegisterIDTxnFee"`
@@ -250,6 +252,7 @@ func Init() error {
 		if Parameters.SyncBatchWindowSize == 0 {
 			Parameters.SyncBatchWindowSize = defaultSyncBatchWindowSize
 		}
+		log.Printf("Set SyncBatchWindowSize to %vMB", Parameters.SyncBatchWindowSize)
 	}
 
 	err := Parameters.verify()


### PR DESCRIPTION
The default parameters now make sure there are <4k low fee txns per block, ~16M per day. This is much more friendly to non-spamming users.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
