### PR TITLE
Rejecting low priority transaction when txpool is full

### DIFF
--- a/api/common/interfaces.go
+++ b/api/common/interfaces.go
@@ -579,7 +579,7 @@ func getId(s Serverer, params map[string]interface{}) map[string]interface{} {
 
 func VerifyAndSendTx(localNode *node.LocalNode, txn *transaction.Transaction) (ErrCode, error) {
 	if err := localNode.AppendTxnPool(txn); err != nil {
-		log.Warningf("Can NOT add the transaction to TxnPool: %v", err)
+		log.Warningf("Add transaction to TxnPool error: %v", err)
 
 		if err == chain.ErrIDRegistered || err == chain.ErrDuplicateGenerateIDTxn {
 			return ErrDuplicatedTx, err

--- a/chain/pool/txpool.go
+++ b/chain/pool/txpool.go
@@ -17,22 +17,28 @@ import (
 	"github.com/nknorg/nkn/util/log"
 )
 
+func compareTxnPriority(txn1, txn2 *transaction.Transaction) int {
+	if txn1.UnsignedTx.Fee > txn2.UnsignedTx.Fee {
+		return 1
+	}
+	if txn1.UnsignedTx.Fee < txn2.UnsignedTx.Fee {
+		return -1
+	}
+	if txn1.GetSize() > txn2.GetSize() {
+		return -1
+	}
+	if txn1.GetSize() < txn2.GetSize() {
+		return 1
+	}
+	return 0
+}
+
 type dropTxnsHeap []*transaction.Transaction
 
-func (s dropTxnsHeap) Len() int      { return len(s) }
-func (s dropTxnsHeap) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-
-func (s dropTxnsHeap) Less(i, j int) bool {
-	if s[i].UnsignedTx.Fee == s[j].UnsignedTx.Fee {
-		return s[i].GetSize() > s[j].GetSize()
-	}
-	return s[i].UnsignedTx.Fee < s[j].UnsignedTx.Fee
-}
-
-func (s *dropTxnsHeap) Push(x interface{}) {
-	*s = append(*s, x.(*transaction.Transaction))
-}
-
+func (s dropTxnsHeap) Len() int            { return len(s) }
+func (s dropTxnsHeap) Swap(i, j int)       { s[i], s[j] = s[j], s[i] }
+func (s dropTxnsHeap) Less(i, j int) bool  { return compareTxnPriority(s[i], s[j]) < 0 }
+func (s *dropTxnsHeap) Push(x interface{}) { *s = append(*s, x.(*transaction.Transaction)) }
 func (s *dropTxnsHeap) Pop() interface{} {
 	old := *s
 	n := len(old)
@@ -42,7 +48,8 @@ func (s *dropTxnsHeap) Pop() interface{} {
 }
 
 var (
-	ErrDuplicatedTx = errors.New("duplicate transaction check failed")
+	ErrDuplicatedTx      = errors.New("duplicate transaction check failed")
+	ErrRejectLowPriority = errors.New("txpool full, rejecting transaction with low priority")
 )
 
 // TxnPool is a list of txns that need to by add to ledger sent by user.
@@ -54,6 +61,9 @@ type TxnPool struct {
 	blockValidationState *chain.BlockValidationState
 	txnCount             int32
 	txnSize              int64
+
+	sync.RWMutex
+	lastDroppedTxn *transaction.Transaction
 }
 
 func NewTxPool() *TxnPool {
@@ -82,12 +92,25 @@ func isTxPoolFull(txnCount int32, txnSize int64) bool {
 	return false
 }
 
+func (tp *TxnPool) getLastDroppedTxn() *transaction.Transaction {
+	tp.RLock()
+	defer tp.RUnlock()
+	return tp.lastDroppedTxn
+}
+
+func (tp *TxnPool) setLastDroppedTxn(txn *transaction.Transaction) {
+	tp.Lock()
+	defer tp.Unlock()
+	tp.lastDroppedTxn = txn
+}
+
 func (tp *TxnPool) DropTxns() {
 	currentTxnCount := atomic.LoadInt32(&tp.txnCount)
 	currentTxnSize := atomic.LoadInt64(&tp.txnSize)
 
 	if !isTxPoolFull(currentTxnCount, currentTxnSize) {
 		log.Infof("DropTxns: %v txns (%v bytes) in txpool, no need to drop", currentTxnCount, currentTxnSize)
+		tp.setLastDroppedTxn(nil)
 		return
 	}
 
@@ -192,10 +215,21 @@ func (tp *TxnPool) DropTxns() {
 	}
 	log.Infof("DropTxns: dropped %v txns (%v bytes)", len(txnsDropped), bytesDropped)
 
+	if len(txnsDropped) > 0 {
+		tp.setLastDroppedTxn(txnsDropped[len(txnsDropped)-1])
+	} else {
+		tp.setLastDroppedTxn(nil)
+	}
+
 	return
 }
 
 func (tp *TxnPool) AppendTxnPool(txn *transaction.Transaction) error {
+	lastDroppedTxn := tp.getLastDroppedTxn()
+	if lastDroppedTxn != nil && compareTxnPriority(txn, lastDroppedTxn) <= 0 {
+		return ErrRejectLowPriority
+	}
+
 	sender, err := txn.GetProgramHashes()
 	if err != nil {
 		return err
@@ -207,7 +241,7 @@ func (tp *TxnPool) AppendTxnPool(txn *transaction.Transaction) error {
 	}
 
 	if _, err := list.Get(txn.UnsignedTx.Nonce); err != nil && list.Full() {
-		return errors.New("txpool full, too many transaction in txpool")
+		return errors.New("account txpool full, too many transaction in list")
 	}
 
 	// 2. verify txn

--- a/node/transaction.go
+++ b/node/transaction.go
@@ -356,11 +356,10 @@ func (localNode *LocalNode) handleTransactionsMessage(txnMsg *pb.Transactions) (
 		}
 
 		err := localNode.AppendTxnPool(txn)
-		if err == pool.ErrDuplicatedTx {
+		if err == pool.ErrDuplicatedTx || err == pool.ErrRejectLowPriority {
 			return false, nil
 		}
 		if err != nil {
-			log.Warningf("Verify transaction failed when append to txn pool: %v", err)
 			return false, err
 		}
 	}


### PR DESCRIPTION
This should greatly reduce node load (CPU, RAM, IO) when txpool is full.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
