### PR TITLE
Add height as VerifyTransaction argument for Go SDK usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,14 @@ all: ## Build binaries for all available architectures
 	make crossbuild GOOS=windows GOARCH=amd64
 	make crossbuild GOOS=windows GOARCH=386
 
-.PHONY: build_local, no_web
-build_local: web ## Build local binaries without providing specific GOOS/GOARCH
+.PHONY: no_web
 no_web:
 	$(GC) $(BUILD_NKND_PARAM) nknd.go
 	$(GC) $(BUILD_NKNC_PARAM) nknc.go
+
+.PHONY: build_local
+build_local: web ## Build local binaries without providing specific GOOS/GOARCH
+	${MAKE} no_web
 	## the following parts will be removed after the transition period from testnet to mainnet
 	[ -s "wallet.dat" ] && [ -s "wallet.pswd" ] && ! [ -s "wallet.json" ] && cat wallet.pswd wallet.pswd | ./nknc wallet -c || :
 	[ -s "config.json" ] && ! [ -s "config.json.bk" ] && grep -qE "022d52b07dff29ae6ee22295da2dc315fef1e2337de7ab6e51539d379aa35b9503|0149c42944eea91f094c16538eff0449d4d1e236f31c8c706b2e40e98402984c" config.json && mv config.json config.json.bk && cp config.mainnet.json config.json || :

--- a/chain/blockValidator.go
+++ b/chain/blockValidator.go
@@ -118,7 +118,7 @@ func TransactionCheck(ctx context.Context, block *block.Block) error {
 		if i != 0 && txn.UnsignedTx.Payload.Type == pb.COINBASE_TYPE {
 			return errors.New("Coinbase transaction order is incorrect")
 		}
-		if err := VerifyTransaction(txn); err != nil {
+		if err := VerifyTransaction(txn, block.Header.UnsignedHeader.Height); err != nil {
 			return fmt.Errorf("transaction sanity check failed: %v", err)
 		}
 		if err := bvs.VerifyTransactionWithBlock(txn, block.Header.UnsignedHeader.Height); err != nil {

--- a/chain/mining.go
+++ b/chain/mining.go
@@ -110,7 +110,7 @@ func (bm *BuiltinMining) BuildBlock(ctx context.Context, height uint32, chordID 
 			break
 		}
 
-		if err := VerifyTransaction(txn); err != nil {
+		if err := VerifyTransaction(txn, height); err != nil {
 			log.Warningf("invalid transaction: %v", err)
 			txnCollection.Pop()
 			continue

--- a/chain/pool/txpool.go
+++ b/chain/pool/txpool.go
@@ -245,7 +245,7 @@ func (tp *TxnPool) AppendTxnPool(txn *transaction.Transaction) error {
 	}
 
 	// 2. verify txn
-	if err := chain.VerifyTransaction(txn); err != nil {
+	if err := chain.VerifyTransaction(txn, chain.DefaultLedger.Store.GetHeight()+1); err != nil {
 		return err
 	}
 

--- a/node/relay.go
+++ b/node/relay.go
@@ -174,12 +174,14 @@ func (rs *RelayService) broadcastSigChain(sigChain *pb.SigChain) error {
 		return err
 	}
 
-	err = chain.VerifyTransaction(txn)
+	currentHeight := chain.DefaultLedger.Store.GetHeight()
+
+	err = chain.VerifyTransaction(txn, currentHeight+1)
 	if err != nil {
 		return err
 	}
 
-	porPkg, err := por.GetPorServer().AddSigChainFromTx(txn, chain.DefaultLedger.Store.GetHeight())
+	porPkg, err := por.GetPorServer().AddSigChainFromTx(txn, currentHeight)
 	if err != nil {
 		return err
 	}

--- a/node/transaction.go
+++ b/node/transaction.go
@@ -180,7 +180,9 @@ func (localNode *LocalNode) startRequestingSigChainTxn() {
 					continue
 				}
 
-				if !por.GetPorServer().ShouldAddSigChainToCache(chain.DefaultLedger.Store.GetHeight(), info.height, info.hash) {
+				currentHeight := chain.DefaultLedger.Store.GetHeight()
+
+				if !por.GetPorServer().ShouldAddSigChainToCache(currentHeight, info.height, info.hash) {
 					continue
 				}
 
@@ -197,7 +199,7 @@ func (localNode *LocalNode) startRequestingSigChainTxn() {
 
 				requestedHashCache.Set(info.hash, struct{}{})
 
-				err = chain.VerifyTransaction(txn)
+				err = chain.VerifyTransaction(txn, currentHeight+1)
 				if err != nil {
 					log.Warningf("Verify sigchain txn error: %v", err)
 					continue


### PR DESCRIPTION
Currently height will be read from local chain db, so sdk cannot use VerifyTransaction function to verify transaction.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
