### PR TITLE
Set rpc server KeepAlivesEnabled to false

### DIFF
--- a/api/httpjson/RPCserver.go
+++ b/api/httpjson/RPCserver.go
@@ -238,8 +238,9 @@ func (s *RPCServer) Start() {
 		Handler:      rpcServeMux,
 		ReadTimeout:  config.Parameters.RPCReadTimeout * time.Second,
 		WriteTimeout: config.Parameters.RPCWriteTimeout * time.Second,
-		IdleTimeout:  config.Parameters.KeepAliveTimeout * time.Second,
+		IdleTimeout:  config.Parameters.RPCIdleTimeout * time.Second,
 	}
+	httpServer.SetKeepAlivesEnabled(config.Parameters.RPCKeepAlivesEnabled)
 	httpServer.Serve(listener)
 }
 

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -166,7 +166,8 @@ var (
 		SyncBlocksMaxMemorySize:      0,
 		RPCReadTimeout:               5,
 		RPCWriteTimeout:              10,
-		KeepAliveTimeout:             15,
+		RPCIdleTimeout:               0,
+		RPCKeepAlivesEnabled:         false,
 		NATPortMappingTimeout:        365 * 86400,
 		NumTxnPerBlock:               256,
 		TxPoolPerAccountTxCap:        32,
@@ -227,10 +228,11 @@ type Configuration struct {
 	NumTxnPerBlock               uint32        `json:"NumTxnPerBlock"`
 	TxPoolPerAccountTxCap        uint32        `json:"TxPoolPerAccountTxCap"`
 	TxPoolTotalTxCap             uint32        `json:"TxPoolTotalTxCap"`
-	TxPoolMaxMemorySize          uint32        `json:"TxPoolMaxMemorySize"`   // in megabytes (MB)
-	RPCReadTimeout               time.Duration `json:"RPCReadTimeout"`        // in seconds
-	RPCWriteTimeout              time.Duration `json:"RPCWriteTimeout"`       // in seconds
-	KeepAliveTimeout             time.Duration `json:"KeepAliveTimeout"`      // in seconds
+	TxPoolMaxMemorySize          uint32        `json:"TxPoolMaxMemorySize"` // in megabytes (MB)
+	RPCReadTimeout               time.Duration `json:"RPCReadTimeout"`      // in seconds
+	RPCWriteTimeout              time.Duration `json:"RPCWriteTimeout"`     // in seconds
+	RPCIdleTimeout               time.Duration `json:"RPCIdleTimeout"`      // in seconds
+	RPCKeepAlivesEnabled         bool          `json:"RPCKeepAlivesEnabled"`
 	NATPortMappingTimeout        time.Duration `json:"NATPortMappingTimeout"` // in seconds
 	LogPath                      string        `json:"LogPath"`
 	ChainDBPath                  string        `json:"ChainDBPath"`


### PR DESCRIPTION
This helps reduce the number of connections a NKN node maintains.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
