### PR TITLE
Handle receiving blocks with invalid signature

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -25,6 +25,7 @@ type Consensus struct {
 	startOnce           sync.Once
 	proposals           common.Cache
 	requestProposalChan chan *requestProposalInfo
+	neighborBlacklist   sync.Map
 	mining              chain.Mining
 	txnCollector        *chain.TxnCollector
 

--- a/consensus/proposal.go
+++ b/consensus/proposal.go
@@ -350,6 +350,10 @@ func (consensus *Consensus) requestProposal(neighbor *node.RemoteNode, blockHash
 		}
 	}
 
+	if err = chain.SignatureCheck(b.Header); err != nil {
+		return nil, fmt.Errorf("Proposal fails to pass signature check: %v", err)
+	}
+
 	var txnsRoot common.Uint256
 	poolTxns := make([]*transaction.Transaction, 0, len(replyMsg.TransactionsHash))
 	missingTxnsHash := make([][]byte, 0, len(replyMsg.TransactionsHash))

--- a/consensus/proposal.go
+++ b/consensus/proposal.go
@@ -272,6 +272,10 @@ func (consensus *Consensus) receiveProposalHash(neighborID string, height uint32
 		return nil
 	}
 
+	if _, ok := consensus.neighborBlacklist.Load(neighborID); ok {
+		return fmt.Errorf("ignore block hash %s from blacklist neighbor %s", blockHash.ToHexString(), neighborID)
+	}
+
 	expectedHeight := consensus.GetExpectedHeight()
 	if height != expectedHeight {
 		return fmt.Errorf("Receive invalid block hash height %d instead of %d", height, expectedHeight)
@@ -351,7 +355,10 @@ func (consensus *Consensus) requestProposal(neighbor *node.RemoteNode, blockHash
 	}
 
 	if err = chain.SignatureCheck(b.Header); err != nil {
-		return nil, fmt.Errorf("Proposal fails to pass signature check: %v", err)
+		err = fmt.Errorf("Proposal fails to pass signature check: %v", err)
+		consensus.neighborBlacklist.Store(neighbor.GetID(), err)
+		log.Infof("Add neighbor %s to blacklist because: %v", neighbor.GetID(), err)
+		return nil, err
 	}
 
 	var txnsRoot common.Uint256


### PR DESCRIPTION
* Node will not cache block with invalid signature
* Add neighbor who sent block with invalid signature to blacklist

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
