### PR TITLE
Use periodical ping/pong message to detect client timeout rapidly

### DIFF
--- a/api/websocket/messagebuffer/messagebuffer.go
+++ b/api/websocket/messagebuffer/messagebuffer.go
@@ -22,9 +22,6 @@ func NewMessageBuffer() *MessageBuffer {
 
 // AddMessage adds a message to message buffer
 func (messageBuffer *MessageBuffer) AddMessage(clientID []byte, msg *pb.Relay) {
-	if msg.MaxHoldingSeconds == 0 {
-		return
-	}
 	clientIDStr := hex.EncodeToString(clientID)
 	messageBuffer.Lock()
 	defer messageBuffer.Unlock()

--- a/api/websocket/server/delayedchan.go
+++ b/api/websocket/server/delayedchan.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"time"
+)
+
+type DelayedChan struct {
+	buffer chan *delayedValue
+	delay  time.Duration
+}
+
+type delayedValue struct {
+	value       interface{}
+	releaseTime time.Time
+}
+
+func NewDelayedChan(size int, delay time.Duration) *DelayedChan {
+	buffer := make(chan *delayedValue, size)
+	return &DelayedChan{
+		buffer: buffer,
+		delay:  delay,
+	}
+}
+
+func (dc *DelayedChan) Push(v interface{}) bool {
+	dv := &delayedValue{
+		value:       v,
+		releaseTime: time.Now().Add(dc.delay),
+	}
+	select {
+	case dc.buffer <- dv:
+		return true
+	default:
+		return false
+	}
+}
+
+func (dc *DelayedChan) Pop() (interface{}, bool) {
+	dv, ok := <-dc.buffer
+	if !ok {
+		return nil, false
+	}
+	if dv.releaseTime.After(time.Now()) {
+		time.Sleep(time.Until(dv.releaseTime))
+	}
+	return dv.value, true
+}


### PR DESCRIPTION
Use periodical ping/pong message to detect client timeout rapidly. This can prevent reduce message lost caused by sending to broken clients.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
