### PR TITLE
Add minimal number of neighbor samples to help bootstrap network

### DIFF
--- a/consensus/proposal.go
+++ b/consensus/proposal.go
@@ -79,10 +79,10 @@ func (consensus *Consensus) waitAndHandleProposal() (*election.Election, error) 
 		if elc.NeighborVoteCount() > 0 {
 			timerStartOnce.Do(func() {
 				timer.StopTimer(timeoutTimer)
-				electionStartTimer.Reset(electionStartDelay)
+				electionStartTimer.Reset(electionStartDelay - initialVoteDelay)
 				now := time.Now()
-				verifyDeadline = now.Add(proposalVerificationTimeout)
-				initialVoteDeadline = now.Add(initialVoteDelay)
+				verifyDeadline = now.Add(proposalVerificationTimeout - initialVoteDelay)
+				initialVoteDeadline = now
 			})
 			break
 		}

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -34,9 +34,13 @@ const (
 	SigChainBlockDelay           = 1
 	SigChainPropogationTime      = 2
 	GossipSampleChordNeighbor    = 0.1
+	GossipMinChordNeighbor       = 3
 	GossipSampleRandomNeighbor   = 1.0
+	GossipMinRandomNeighbor      = 0
 	VotingSampleChordNeighbor    = 0.5
+	VotingMinChordNeighbor       = 4
 	VotingSampleRandomNeighbor   = 0.0
+	VotingMinRandomNeighbor      = 0
 	HeaderVersion                = 1
 	DBVersion                    = 0x01
 	InitialIssueAddress          = "NKNFCrUMFPkSeDRMG2ME21hD6wBCA2poc347"


### PR DESCRIPTION
This solves the insufficient propagation problem when there are only a few nodes and helps network to bootstrap faster.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
