### PR TITLE
Fix nknc create wallet print wrong address

### DIFF
--- a/vault/account.go
+++ b/vault/account.go
@@ -15,7 +15,7 @@ type Account struct {
 }
 
 func NewAccount() (*Account, error) {
-	privateKey, publicKey, err := crypto.GenKeyPair()
+	publicKey, privateKey, err := crypto.GenKeyPair()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Yilun <zyl.skysniper@gmail.com>

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
