### PR TITLE
Upgrade wallet format: use scrypt as kdf instead of sha256

### DIFF
--- a/api/common/helper.go
+++ b/api/common/helper.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nknorg/nkn/vault"
 )
 
-func MakeTransferTransaction(wallet vault.Wallet, receipt Uint160, nonce uint64, value, fee Fixed64) (*transaction.Transaction, error) {
+func MakeTransferTransaction(wallet *vault.Wallet, receipt Uint160, nonce uint64, value, fee Fixed64) (*transaction.Transaction, error) {
 	account, err := wallet.GetDefaultAccount()
 	if err != nil {
 		return nil, err
@@ -31,7 +31,7 @@ func MakeTransferTransaction(wallet vault.Wallet, receipt Uint160, nonce uint64,
 	return txn, nil
 }
 
-func MakeSigChainTransaction(wallet vault.Wallet, sigChain []byte, nonce uint64) (*transaction.Transaction, error) {
+func MakeSigChainTransaction(wallet *vault.Wallet, sigChain []byte, nonce uint64) (*transaction.Transaction, error) {
 	account, err := wallet.GetDefaultAccount()
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func MakeSigChainTransaction(wallet vault.Wallet, sigChain []byte, nonce uint64)
 	return txn, nil
 }
 
-func MakeRegisterNameTransaction(wallet vault.Wallet, name string, nonce uint64, regFee Fixed64, fee Fixed64) (*transaction.Transaction, error) {
+func MakeRegisterNameTransaction(wallet *vault.Wallet, name string, nonce uint64, regFee Fixed64, fee Fixed64) (*transaction.Transaction, error) {
 	account, err := wallet.GetDefaultAccount()
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func MakeRegisterNameTransaction(wallet vault.Wallet, name string, nonce uint64,
 	return txn, nil
 }
 
-func MakeTransferNameTransaction(wallet vault.Wallet, name string, nonce uint64, fee Fixed64, to []byte) (*transaction.Transaction, error) {
+func MakeTransferNameTransaction(wallet *vault.Wallet, name string, nonce uint64, fee Fixed64, to []byte) (*transaction.Transaction, error) {
 	account, err := wallet.GetDefaultAccount()
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func MakeTransferNameTransaction(wallet vault.Wallet, name string, nonce uint64,
 	return txn, nil
 }
 
-func MakeDeleteNameTransaction(wallet vault.Wallet, name string, nonce uint64, fee Fixed64) (*transaction.Transaction, error) {
+func MakeDeleteNameTransaction(wallet *vault.Wallet, name string, nonce uint64, fee Fixed64) (*transaction.Transaction, error) {
 	account, err := wallet.GetDefaultAccount()
 	if err != nil {
 		return nil, err
@@ -110,7 +110,7 @@ func MakeDeleteNameTransaction(wallet vault.Wallet, name string, nonce uint64, f
 	return txn, nil
 }
 
-func MakeSubscribeTransaction(wallet vault.Wallet, identifier string, topic string, duration uint32, meta string, nonce uint64, fee Fixed64) (*transaction.Transaction, error) {
+func MakeSubscribeTransaction(wallet *vault.Wallet, identifier string, topic string, duration uint32, meta string, nonce uint64, fee Fixed64) (*transaction.Transaction, error) {
 	account, err := wallet.GetDefaultAccount()
 	if err != nil {
 		return nil, err
@@ -130,7 +130,7 @@ func MakeSubscribeTransaction(wallet vault.Wallet, identifier string, topic stri
 	return txn, nil
 }
 
-func MakeUnsubscribeTransaction(wallet vault.Wallet, identifier string, topic string, nonce uint64, fee Fixed64) (*transaction.Transaction, error) {
+func MakeUnsubscribeTransaction(wallet *vault.Wallet, identifier string, topic string, nonce uint64, fee Fixed64) (*transaction.Transaction, error) {
 	account, err := wallet.GetDefaultAccount()
 	if err != nil {
 		return nil, err
@@ -150,7 +150,7 @@ func MakeUnsubscribeTransaction(wallet vault.Wallet, identifier string, topic st
 	return txn, nil
 }
 
-func MakeGenerateIDTransaction(ctx context.Context, wallet vault.Wallet, regFee Fixed64, nonce uint64, txnFee Fixed64, maxTxnHash Uint256) (*transaction.Transaction, error) {
+func MakeGenerateIDTransaction(ctx context.Context, wallet *vault.Wallet, regFee Fixed64, nonce uint64, txnFee Fixed64, maxTxnHash Uint256) (*transaction.Transaction, error) {
 	account, err := wallet.GetDefaultAccount()
 	if err != nil {
 		return nil, err
@@ -192,7 +192,7 @@ func MakeGenerateIDTransaction(ctx context.Context, wallet vault.Wallet, regFee 
 	return txn, nil
 }
 
-func MakeNanoPayTransaction(wallet vault.Wallet, recipient Uint160, id uint64, amount Fixed64, txnExpiration, nanoPayExpiration uint32) (*transaction.Transaction, error) {
+func MakeNanoPayTransaction(wallet *vault.Wallet, recipient Uint160, id uint64, amount Fixed64, txnExpiration, nanoPayExpiration uint32) (*transaction.Transaction, error) {
 	account, err := wallet.GetDefaultAccount()
 	if err != nil {
 		return nil, err
@@ -213,7 +213,7 @@ func MakeNanoPayTransaction(wallet vault.Wallet, recipient Uint160, id uint64, a
 	return txn, nil
 }
 
-func MakeIssueAssetTransaction(wallet vault.Wallet, name, symbol string, totalSupply Fixed64, precision uint32, nonce uint64, fee Fixed64) (*transaction.Transaction, error) {
+func MakeIssueAssetTransaction(wallet *vault.Wallet, name, symbol string, totalSupply Fixed64, precision uint32, nonce uint64, fee Fixed64) (*transaction.Transaction, error) {
 	account, err := wallet.GetDefaultAccount()
 	if err != nil {
 		return nil, err

--- a/api/common/interfaces.go
+++ b/api/common/interfaces.go
@@ -82,7 +82,7 @@ func getBlock(s Serverer, params map[string]interface{}) map[string]interface{} 
 			return respPacking(UNKNOWN_HASH, err.Error())
 		}
 	} else if str, ok := params["hash"].(string); ok {
-		hex, err := common.HexStringToBytes(str)
+		hex, err := hex.DecodeString(str)
 		if err != nil {
 			return respPacking(INVALID_PARAMS, err.Error())
 		}
@@ -134,7 +134,7 @@ func GetBlockTransactions(block *block.Block) interface{} {
 	trans := make([]string, len(block.Transactions))
 	for i := 0; i < len(block.Transactions); i++ {
 		h := block.Transactions[i].Hash()
-		trans[i] = common.BytesToHexString(h.ToArray())
+		trans[i] = hex.EncodeToString(h.ToArray())
 	}
 	hash := block.Hash()
 	type BlockTransactions struct {
@@ -143,7 +143,7 @@ func GetBlockTransactions(block *block.Block) interface{} {
 		Transactions []string
 	}
 	b := BlockTransactions{
-		Hash:         common.BytesToHexString(hash.ToArray()),
+		Hash:         hex.EncodeToString(hash.ToArray()),
 		Height:       block.Header.UnsignedHeader.Height,
 		Transactions: trans,
 	}
@@ -264,7 +264,7 @@ func getTransaction(s Serverer, params map[string]interface{}) map[string]interf
 		return respPacking(INVALID_PARAMS, "hash should be a string")
 	}
 
-	hex, err := common.HexStringToBytes(str)
+	hex, err := hex.DecodeString(str)
 	if err != nil {
 		return respPacking(INVALID_PARAMS, err.Error())
 	}
@@ -301,7 +301,7 @@ func sendRawTransaction(s Serverer, params map[string]interface{}) map[string]in
 
 	var hash common.Uint256
 	if str, ok := params["tx"].(string); ok {
-		hex, err := common.HexStringToBytes(str)
+		hex, err := hex.DecodeString(str)
 		if err != nil {
 			return respPacking(INVALID_PARAMS, err.Error())
 		}
@@ -318,7 +318,7 @@ func sendRawTransaction(s Serverer, params map[string]interface{}) map[string]in
 		return respPacking(INVALID_PARAMS, "tx should be a hex string")
 	}
 
-	return respPacking(SUCCESS, common.BytesToHexString(hash.ToArray()))
+	return respPacking(SUCCESS, hex.EncodeToString(hash.ToArray()))
 }
 
 // getNeighbor gets neighbors of this node
@@ -365,8 +365,8 @@ func NodeInfo(wsAddr, rpcAddr string, pubkey, id []byte) map[string]string {
 	nodeInfo := make(map[string]string)
 	nodeInfo["addr"] = wsAddr
 	nodeInfo["rpcAddr"] = rpcAddr
-	nodeInfo["pubkey"] = common.BytesToHexString(pubkey)
-	nodeInfo["id"] = common.BytesToHexString(id)
+	nodeInfo["pubkey"] = hex.EncodeToString(pubkey)
+	nodeInfo["id"] = hex.EncodeToString(id)
 	return nodeInfo
 }
 
@@ -464,7 +464,7 @@ func GetBalanceByAssetID(s Serverer, params map[string]interface{}) map[string]i
 		return respPacking(INVALID_PARAMS, "asset id should be a string")
 	}
 
-	hexAssetID, err := common.HexStringToBytes(id)
+	hexAssetID, err := hex.DecodeString(id)
 	if err != nil {
 		return respPacking(INVALID_PARAMS, err.Error())
 	}
@@ -561,7 +561,7 @@ func getId(s Serverer, params map[string]interface{}) map[string]interface{} {
 	}
 
 	ret := map[string]interface{}{
-		"id": common.BytesToHexString(id),
+		"id": hex.EncodeToString(id),
 	}
 
 	return respPacking(SUCCESS, ret)
@@ -757,7 +757,7 @@ func getAsset(s Serverer, params map[string]interface{}) map[string]interface{} 
 		return respPacking(INVALID_PARAMS, "asset ID should be a string")
 	}
 
-	hexAssetID, err := common.HexStringToBytes(str)
+	hexAssetID, err := hex.DecodeString(str)
 	if err != nil {
 		return respPacking(INVALID_PARAMS, err.Error())
 	}

--- a/api/httpjson/RPCserver.go
+++ b/api/httpjson/RPCserver.go
@@ -25,7 +25,7 @@ type RPCServer struct {
 	httpListener  string
 	httpsListener string
 	localNode     *node.LocalNode
-	wallet        vault.Wallet
+	wallet        *vault.Wallet
 	limiter       *rate.Limiter
 }
 
@@ -40,7 +40,7 @@ type ServeMux struct {
 }
 
 // NewServer will create a new RPC server instance.
-func NewServer(localNode *node.LocalNode, wallet vault.Wallet) *RPCServer {
+func NewServer(localNode *node.LocalNode, wallet *vault.Wallet) *RPCServer {
 	return &RPCServer{
 		mainMux: ServeMux{
 			m: make(map[string]common.Handler),

--- a/api/httpjson/client/client.go
+++ b/api/httpjson/client/client.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/nknorg/nkn/api/common"
-	. "github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/crypto"
 	"github.com/nknorg/nkn/util/log"
 )
@@ -114,7 +113,7 @@ func GetMyExtIP(remote string, ip []byte) (string, error) {
 
 func GetID(remote string, publicKey []byte) ([]byte, error) {
 	resp, err := Call(remote, "getid", 0, map[string]interface{}{
-		"publickey": BytesToHexString(publicKey),
+		"publickey": hex.EncodeToString(publicKey),
 	})
 	if err != nil {
 		return nil, err
@@ -141,7 +140,7 @@ func GetID(remote string, publicKey []byte) ([]byte, error) {
 		return nil, fmt.Errorf("GetID(%s) resp error: %v", remote, string(resp))
 	}
 
-	idSlice, err := HexStringToBytes(ret.Result.Id)
+	idSlice, err := hex.DecodeString(ret.Result.Id)
 	if err != nil {
 		return nil, err
 	}

--- a/api/websocket/server/server.go
+++ b/api/websocket/server/server.go
@@ -60,13 +60,13 @@ type WsServer struct {
 	ActionMap             map[string]Handler
 	TxHashMap             map[string]string //key: txHash   value:sessionid
 	localNode             *node.LocalNode
-	wallet                vault.Wallet
+	wallet                *vault.Wallet
 	messageBuffer         *messagebuffer.MessageBuffer
 	messageDeliveredCache *DelayedChan
 	sigChainCache         Cache
 }
 
-func InitWsServer(localNode *node.LocalNode, wallet vault.Wallet) *WsServer {
+func InitWsServer(localNode *node.LocalNode, wallet *vault.Wallet) *WsServer {
 	ws := &WsServer{
 		Upgrader:              websocket.Upgrader{},
 		SessionList:           session.NewSessionList(),
@@ -201,7 +201,7 @@ func (ws *WsServer) registryMethod() {
 
 		res := make(map[string]interface{})
 		res["node"] = common.NodeInfo(wsAddr, rpcAddr, pubkey, id)
-		res["sigChainBlockHash"] = BytesToHexString(sigChainBlockHash.ToArray())
+		res["sigChainBlockHash"] = hex.EncodeToString(sigChainBlockHash.ToArray())
 
 		return common.RespPacking(res, common.SUCCESS)
 	}

--- a/api/websocket/websocket.go
+++ b/api/websocket/websocket.go
@@ -1,13 +1,13 @@
 package websocket
 
 import (
+	"encoding/hex"
 	"encoding/json"
 
 	"github.com/nknorg/nkn/api/common"
 	"github.com/nknorg/nkn/api/websocket/server"
 	"github.com/nknorg/nkn/block"
 	"github.com/nknorg/nkn/chain"
-	. "github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/event"
 	"github.com/nknorg/nkn/node"
 	"github.com/nknorg/nkn/util/config"
@@ -23,7 +23,7 @@ var (
 	pushBlockTxsFlag bool = false
 )
 
-func NewServer(localNode *node.LocalNode, w vault.Wallet) *server.WsServer {
+func NewServer(localNode *node.LocalNode, w *vault.Wallet) *server.WsServer {
 	//	common.SetNode(n)
 	event.Queue.Subscribe(event.NewBlockProduced, SendBlock2WSclient)
 	ws = server.InitWsServer(localNode, w)
@@ -79,7 +79,7 @@ func PushBlock(v interface{}) {
 	if block, ok := v.(*block.Block); ok {
 		if pushRawBlockFlag {
 			dt, _ := block.Marshal()
-			resp["Result"] = BytesToHexString(dt)
+			resp["Result"] = hex.EncodeToString(dt)
 		} else {
 			info, _ := block.GetInfo()
 			var x interface{}
@@ -118,7 +118,7 @@ func PushSigChainBlockHash(v interface{}) {
 			return
 		}
 		resp["Action"] = "updateSigChainBlockHash"
-		resp["Result"] = BytesToHexString(sigChainBlockHash.ToArray())
+		resp["Result"] = hex.EncodeToString(sigChainBlockHash.ToArray())
 		ws.PushResult(resp)
 	}
 }

--- a/block/block.go
+++ b/block/block.go
@@ -2,6 +2,7 @@ package block
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -165,7 +166,7 @@ func ComputeID(preBlockHash, txnHash Uint256, randomBeacon []byte) []byte {
 }
 
 func GenesisBlockInit() (*Block, error) {
-	genesisSignerPk, err := HexStringToBytes(config.Parameters.GenesisBlockProposer)
+	genesisSignerPk, err := hex.DecodeString(config.Parameters.GenesisBlockProposer)
 	if err != nil {
 		return nil, fmt.Errorf("parse GenesisBlockProposer error: %v", err)
 	}

--- a/block/header.go
+++ b/block/header.go
@@ -2,6 +2,7 @@ package block
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -122,17 +123,17 @@ func (h *Header) GetInfo() ([]byte, error) {
 	hash := h.Hash()
 	info := &headerInfo{
 		Version:          h.UnsignedHeader.Version,
-		PrevBlockHash:    BytesToHexString(h.UnsignedHeader.PrevBlockHash),
-		TransactionsRoot: BytesToHexString(h.UnsignedHeader.TransactionsRoot),
-		StateRoot:        BytesToHexString(h.UnsignedHeader.StateRoot),
+		PrevBlockHash:    hex.EncodeToString(h.UnsignedHeader.PrevBlockHash),
+		TransactionsRoot: hex.EncodeToString(h.UnsignedHeader.TransactionsRoot),
+		StateRoot:        hex.EncodeToString(h.UnsignedHeader.StateRoot),
 		Timestamp:        h.UnsignedHeader.Timestamp,
 		Height:           h.UnsignedHeader.Height,
-		RandomBeacon:     BytesToHexString(h.UnsignedHeader.RandomBeacon),
-		WinnerHash:       BytesToHexString(h.UnsignedHeader.WinnerHash),
+		RandomBeacon:     hex.EncodeToString(h.UnsignedHeader.RandomBeacon),
+		WinnerHash:       hex.EncodeToString(h.UnsignedHeader.WinnerHash),
 		WinnerType:       h.UnsignedHeader.WinnerType.String(),
-		SignerPk:         BytesToHexString(h.UnsignedHeader.SignerPk),
-		SignerId:         BytesToHexString(h.UnsignedHeader.SignerId),
-		Signature:        BytesToHexString(h.Signature),
+		SignerPk:         hex.EncodeToString(h.UnsignedHeader.SignerPk),
+		SignerId:         hex.EncodeToString(h.UnsignedHeader.SignerId),
+		Signature:        hex.EncodeToString(h.Signature),
 		Hash:             hash.ToHexString(),
 	}
 

--- a/chain/ledger.go
+++ b/chain/ledger.go
@@ -23,7 +23,7 @@ func (l *Ledger) IsDoubleSpend(Tx *transaction.Transaction) bool {
 // get the default ledger
 func GetDefaultLedger() (*Ledger, error) {
 	if DefaultLedger == nil {
-		return nil, errors.New("[Ledger], GetDefaultLedger failed, DefaultLedger not Exist.")
+		return nil, errors.New("[Ledger] GetDefaultLedger failed, DefaultLedger not Exist.")
 	}
 	return DefaultLedger, nil
 }
@@ -41,11 +41,11 @@ func GetDefaultLedger() (*Ledger, error) {
 func (l *Ledger) GetBlockWithHeight(height uint32) (*block.Block, error) {
 	temp, err := l.Store.GetBlockHash(height)
 	if err != nil {
-		return nil, errors.New("[Ledger],GetBlockWithHeight failed with height=" + string(height))
+		return nil, errors.New("[Ledger] GetBlockWithHeight failed with height=" + string(height))
 	}
 	bk, err := DefaultLedger.Store.GetBlock(temp)
 	if err != nil {
-		return nil, errors.New("[Ledger],GetBlockWithHeight failed with hash=" + temp.ToString())
+		return nil, errors.New("[Ledger] GetBlockWithHeight failed with hash=" + temp.ToString())
 	}
 	return bk, nil
 }
@@ -54,7 +54,7 @@ func (l *Ledger) GetBlockWithHeight(height uint32) (*block.Block, error) {
 func (l *Ledger) GetBlockWithHash(hash Uint256) (*block.Block, error) {
 	bk, err := l.Store.GetBlock(hash)
 	if err != nil {
-		return nil, errors.New("[Ledger],GetBlockWithHeight failed with hash=" + hash.ToString())
+		return nil, errors.New("[Ledger] GetBlockWithHeight failed with hash=" + hash.ToString())
 	}
 	return bk, nil
 }
@@ -68,7 +68,7 @@ func (l *Ledger) BlockInLedger(hash Uint256) bool {
 func (l *Ledger) GetTransactionWithHash(hash Uint256) (*transaction.Transaction, error) {
 	tx, err := l.Store.GetTransaction(hash)
 	if err != nil {
-		return nil, errors.New("[Ledger],GetTransactionWithHash failed with hash=" + hash.ToString())
+		return nil, errors.New("[Ledger] GetTransactionWithHash failed with hash=" + hash.ToString())
 	}
 	return tx, nil
 }

--- a/chain/trie/node.go
+++ b/chain/trie/node.go
@@ -2,11 +2,11 @@ package trie
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
 
-	"github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/common/serialization"
 	"github.com/nknorg/nkn/util/log"
 )
@@ -76,15 +76,15 @@ func (n *fullNode) fString(ind string) string {
 }
 
 func (n *shortNode) fString(ind string) string {
-	return fmt.Sprintf("{%v: %v} ", common.BytesToHexString(n.Key), n.Val.fString(ind+"  "))
+	return fmt.Sprintf("{%v: %v} ", hex.EncodeToString(n.Key), n.Val.fString(ind+"  "))
 
 }
 func (n hashNode) fString(ind string) string {
-	return fmt.Sprintf("<%s>", common.BytesToHexString(n))
+	return fmt.Sprintf("<%s>", hex.EncodeToString(n))
 
 }
 func (n valueNode) fString(ind string) string {
-	return fmt.Sprintf("%s", common.BytesToHexString(n))
+	return fmt.Sprintf("%s", hex.EncodeToString(n))
 
 }
 

--- a/chain/txValidator.go
+++ b/chain/txValidator.go
@@ -8,11 +8,11 @@ import (
 	"regexp"
 	"sync"
 
+	"github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/crypto/ed25519"
 
 	"github.com/nknorg/nkn/program"
 
-	. "github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/crypto"
 	"github.com/nknorg/nkn/pb"
 	"github.com/nknorg/nkn/transaction"
@@ -110,12 +110,12 @@ func CheckTransactionPayload(txn *transaction.Transaction, height uint32) error 
 	switch txn.UnsignedTx.Payload.Type {
 	case pb.COINBASE_TYPE:
 		pld := payload.(*pb.Coinbase)
-		if len(pld.Sender) != UINT160SIZE && len(pld.Recipient) != UINT160SIZE {
+		if len(pld.Sender) != common.UINT160SIZE && len(pld.Recipient) != common.UINT160SIZE {
 			return errors.New("length of programhash error")
 		}
 
-		donationProgramhash, _ := ToScriptHash(config.DonationAddress)
-		if BytesToUint160(pld.Sender) != donationProgramhash {
+		donationProgramhash, _ := common.ToScriptHash(config.DonationAddress)
+		if common.BytesToUint160(pld.Sender) != donationProgramhash {
 			return errors.New("invalid sender")
 		}
 
@@ -124,11 +124,11 @@ func CheckTransactionPayload(txn *transaction.Transaction, height uint32) error 
 		}
 	case pb.TRANSFER_ASSET_TYPE:
 		pld := payload.(*pb.TransferAsset)
-		if len(pld.Sender) != UINT160SIZE && len(pld.Recipient) != UINT160SIZE {
+		if len(pld.Sender) != common.UINT160SIZE && len(pld.Recipient) != common.UINT160SIZE {
 			return errors.New("length of programhash error")
 		}
 
-		donationProgramhash, _ := ToScriptHash(config.DonationAddress)
+		donationProgramhash, _ := common.ToScriptHash(config.DonationAddress)
 		if bytes.Equal(pld.Sender, donationProgramhash[:]) {
 			return errors.New("illegal transaction sender")
 		}
@@ -147,7 +147,7 @@ func CheckTransactionPayload(txn *transaction.Transaction, height uint32) error 
 			if err = CheckAmount(pld.RegistrationFee); err != nil {
 				return err
 			}
-			if Fixed64(pld.RegistrationFee) < Fixed64(config.MinNameRegistrationFee) {
+			if common.Fixed64(pld.RegistrationFee) < common.Fixed64(config.MinNameRegistrationFee) {
 				return fmt.Errorf("registration fee %s is lower than MinNameRegistrationFee %d", string(pld.Registrant), config.MinNameRegistrationFee)
 			}
 		}
@@ -216,7 +216,7 @@ func CheckTransactionPayload(txn *transaction.Transaction, height uint32) error 
 			return err
 		}
 
-		if Fixed64(pld.RegistrationFee) < Fixed64(config.MinGenIDRegistrationFee) {
+		if common.Fixed64(pld.RegistrationFee) < common.Fixed64(config.MinGenIDRegistrationFee) {
 			return errors.New("registration fee is lower than MinGenIDRegistrationFee")
 		}
 
@@ -227,11 +227,11 @@ func CheckTransactionPayload(txn *transaction.Transaction, height uint32) error 
 	case pb.NANO_PAY_TYPE:
 		pld := payload.(*pb.NanoPay)
 
-		if len(pld.Sender) != UINT160SIZE && len(pld.Recipient) != UINT160SIZE {
+		if len(pld.Sender) != common.UINT160SIZE && len(pld.Recipient) != common.UINT160SIZE {
 			return errors.New("length of programhash error")
 		}
 
-		donationProgramhash, _ := ToScriptHash(config.DonationAddress)
+		donationProgramhash, _ := common.ToScriptHash(config.DonationAddress)
 		if bytes.Equal(pld.Sender, donationProgramhash[:]) {
 			return errors.New("illegal transaction sender")
 		}
@@ -246,7 +246,7 @@ func CheckTransactionPayload(txn *transaction.Transaction, height uint32) error 
 
 	case pb.ISSUE_ASSET_TYPE:
 		pld := payload.(*pb.IssueAsset)
-		if len(pld.Sender) != UINT160SIZE {
+		if len(pld.Sender) != common.UINT160SIZE {
 			return errors.New("length of programhash error")
 		}
 
@@ -317,7 +317,7 @@ func VerifyTransactionWithLedger(txn *transaction.Transaction, height uint32) er
 			return err
 		}
 
-		donationProgramhash, _ := ToScriptHash(config.DonationAddress)
+		donationProgramhash, _ := common.ToScriptHash(config.DonationAddress)
 		amount := DefaultLedger.Store.GetBalance(donationProgramhash)
 		if amount < donationAmount {
 			return errors.New("not sufficient funds in doation account")
@@ -439,8 +439,8 @@ func VerifyTransactionWithLedger(txn *transaction.Transaction, height uint32) er
 		pld := payload.(*pb.NanoPay)
 
 		channelBalance, _, err := DefaultLedger.Store.GetNanoPay(
-			BytesToUint160(pld.Sender),
-			BytesToUint160(pld.Recipient),
+			common.BytesToUint160(pld.Sender),
+			common.BytesToUint160(pld.Recipient),
 			pld.Id,
 		)
 		if err != nil {
@@ -497,8 +497,8 @@ type nanoPay struct {
 
 type BlockValidationState struct {
 	sync.RWMutex
-	txnlist                 map[Uint256]struct{}
-	totalAmount             map[Uint160]Fixed64
+	txnlist                 map[common.Uint256]struct{}
+	totalAmount             map[common.Uint160]common.Fixed64
 	registeredNames         map[string]struct{}
 	nameRegistrants         map[string]struct{}
 	generateIDs             map[string]struct{}
@@ -517,8 +517,8 @@ func NewBlockValidationState() *BlockValidationState {
 }
 
 func (bvs *BlockValidationState) initBlockValidationState() {
-	bvs.txnlist = make(map[Uint256]struct{}, 0)
-	bvs.totalAmount = make(map[Uint160]Fixed64, 0)
+	bvs.txnlist = make(map[common.Uint256]struct{}, 0)
+	bvs.totalAmount = make(map[common.Uint160]common.Fixed64, 0)
 	bvs.registeredNames = make(map[string]struct{}, 0)
 	bvs.nameRegistrants = make(map[string]struct{}, 0)
 	bvs.generateIDs = make(map[string]struct{}, 0)
@@ -606,8 +606,8 @@ func (bvs *BlockValidationState) VerifyTransactionWithBlock(txn *transaction.Tra
 		return err
 	}
 	sender := pg[0]
-	var amount Fixed64
-	fee := Fixed64(txn.UnsignedTx.Fee)
+	var amount common.Fixed64
+	fee := common.Fixed64(txn.UnsignedTx.Fee)
 
 	switch txn.UnsignedTx.Payload.Type {
 	case pb.COINBASE_TYPE:
@@ -616,12 +616,12 @@ func (bvs *BlockValidationState) VerifyTransactionWithBlock(txn *transaction.Tra
 		if err != nil {
 			return err
 		}
-		if Fixed64(coinbase.Amount) != GetRewardByHeight(height)+donationAmount {
+		if common.Fixed64(coinbase.Amount) != GetRewardByHeight(height)+donationAmount {
 			return errors.New("mining reward incorrectly")
 		}
 	case pb.TRANSFER_ASSET_TYPE:
 		transfer := payload.(*pb.TransferAsset)
-		amount = Fixed64(transfer.Amount)
+		amount = common.Fixed64(transfer.Amount)
 	case pb.REGISTER_NAME_TYPE:
 		namePayload := payload.(*pb.RegisterName)
 
@@ -630,13 +630,13 @@ func (bvs *BlockValidationState) VerifyTransactionWithBlock(txn *transaction.Tra
 			return errors.New("[VerifyTransactionWithBlock] duplicate name exist in block")
 		}
 
-		registrant := BytesToHexString(namePayload.Registrant)
+		registrant := hex.EncodeToString(namePayload.Registrant)
 		if config.LegacyNameService.GetValueAtHeight(height) {
 			if _, ok := bvs.nameRegistrants[registrant]; ok {
 				return errors.New("[VerifyTransactionWithBlock] duplicate registrant exist in block")
 			}
 		}
-		amount = Fixed64(namePayload.RegistrationFee)
+		amount = common.Fixed64(namePayload.RegistrationFee)
 
 		defer func() {
 			if e == nil {
@@ -665,7 +665,7 @@ func (bvs *BlockValidationState) VerifyTransactionWithBlock(txn *transaction.Tra
 			return errors.New("[VerifyTransactionWithBlock] duplicate name exist in block")
 		}
 
-		registrant := BytesToHexString(namePayload.Registrant)
+		registrant := hex.EncodeToString(namePayload.Registrant)
 		if config.LegacyNameService.GetValueAtHeight(height) {
 			if _, ok := bvs.nameRegistrants[registrant]; ok {
 				return errors.New("[VerifyTransactionWithBlock] duplicate registrant exist in block")
@@ -736,8 +736,8 @@ func (bvs *BlockValidationState) VerifyTransactionWithBlock(txn *transaction.Tra
 		}()
 	case pb.GENERATE_ID_TYPE:
 		generateIDPayload := payload.(*pb.GenerateID)
-		amount = Fixed64(generateIDPayload.RegistrationFee)
-		publicKey := BytesToHexString(generateIDPayload.PublicKey)
+		amount = common.Fixed64(generateIDPayload.RegistrationFee)
+		publicKey := hex.EncodeToString(generateIDPayload.PublicKey)
 		if _, ok := bvs.generateIDs[publicKey]; ok {
 			return ErrDuplicateGenerateIDTxn
 		}
@@ -757,20 +757,20 @@ func (bvs *BlockValidationState) VerifyTransactionWithBlock(txn *transaction.Tra
 		if height > npPayload.NanoPayExpiration {
 			return errors.New("[VerifyTransactionWithBlock] nano pay has expired")
 		}
-		key := nanoPay{BytesToHexString(npPayload.Sender), BytesToHexString(npPayload.Recipient), npPayload.Id}
+		key := nanoPay{hex.EncodeToString(npPayload.Sender), hex.EncodeToString(npPayload.Recipient), npPayload.Id}
 		if _, ok := bvs.nanoPays[key]; ok {
 			return errors.New("[VerifyTransactionWithBlock] duplicate payment channel exist in block")
 		}
 
 		channelBalance, _, err := DefaultLedger.Store.GetNanoPay(
-			BytesToUint160(npPayload.Sender),
-			BytesToUint160(npPayload.Recipient),
+			common.BytesToUint160(npPayload.Sender),
+			common.BytesToUint160(npPayload.Recipient),
 			npPayload.Id,
 		)
 		if err != nil {
 			return err
 		}
-		amount = Fixed64(npPayload.Amount) - channelBalance
+		amount = common.Fixed64(npPayload.Amount) - channelBalance
 
 		defer func() {
 			if e == nil {
@@ -816,21 +816,21 @@ func (bvs *BlockValidationState) CleanSubmittedTransactions(txns []*transaction.
 			return err
 		}
 		sender := pg[0]
-		var amount Fixed64
-		fee := Fixed64(txn.UnsignedTx.Fee)
+		var amount common.Fixed64
+		fee := common.Fixed64(txn.UnsignedTx.Fee)
 
 		switch txn.UnsignedTx.Payload.Type {
 		case pb.TRANSFER_ASSET_TYPE:
 			transfer := payload.(*pb.TransferAsset)
-			amount = Fixed64(transfer.Amount)
+			amount = common.Fixed64(transfer.Amount)
 		case pb.REGISTER_NAME_TYPE:
 			namePayload := payload.(*pb.RegisterName)
-			amount = Fixed64(namePayload.RegistrationFee)
+			amount = common.Fixed64(namePayload.RegistrationFee)
 
 			name := namePayload.Name
 			delete(bvs.registeredNames, name)
 
-			registrant := BytesToHexString(namePayload.Registrant)
+			registrant := hex.EncodeToString(namePayload.Registrant)
 			delete(bvs.nameRegistrants, registrant)
 
 		case pb.TRANSFER_NAME_TYPE:
@@ -844,7 +844,7 @@ func (bvs *BlockValidationState) CleanSubmittedTransactions(txns []*transaction.
 			name := namePayload.Name
 			delete(bvs.registeredNames, name)
 
-			registrant := BytesToHexString(namePayload.Registrant)
+			registrant := hex.EncodeToString(namePayload.Registrant)
 			delete(bvs.nameRegistrants, registrant)
 		case pb.SUBSCRIBE_TYPE:
 			subscribePayload := payload.(*pb.Subscribe)
@@ -873,12 +873,12 @@ func (bvs *BlockValidationState) CleanSubmittedTransactions(txns []*transaction.
 			}
 		case pb.GENERATE_ID_TYPE:
 			generateIdPayload := payload.(*pb.GenerateID)
-			amount = Fixed64(generateIdPayload.RegistrationFee)
-			publicKey := BytesToHexString(generateIdPayload.PublicKey)
+			amount = common.Fixed64(generateIdPayload.RegistrationFee)
+			publicKey := hex.EncodeToString(generateIdPayload.PublicKey)
 			delete(bvs.generateIDs, publicKey)
 		case pb.NANO_PAY_TYPE:
 			npPayload := payload.(*pb.NanoPay)
-			key := nanoPay{BytesToHexString(npPayload.Sender), BytesToHexString(npPayload.Recipient), npPayload.Id}
+			key := nanoPay{hex.EncodeToString(npPayload.Sender), hex.EncodeToString(npPayload.Recipient), npPayload.Id}
 			delete(bvs.nanoPays, key)
 		case pb.ISSUE_ASSET_TYPE:
 		}
@@ -899,9 +899,9 @@ func (bvs *BlockValidationState) CleanSubmittedTransactions(txns []*transaction.
 	return nil
 }
 
-func (bvs *BlockValidationState) RefreshBlockValidationState(txns []*transaction.Transaction) map[Uint256]error {
+func (bvs *BlockValidationState) RefreshBlockValidationState(txns []*transaction.Transaction) map[common.Uint256]error {
 	bvs.initBlockValidationState()
-	errMap := make(map[Uint256]error, 0)
+	errMap := make(map[common.Uint256]error, 0)
 	for _, tx := range txns {
 		if err := bvs.VerifyTransactionWithBlock(tx, 0); err != nil {
 			errMap[tx.Hash()] = err

--- a/cmd/nknc/common/common.go
+++ b/cmd/nknc/common/common.go
@@ -60,17 +60,6 @@ func FormatOutput(o []byte) error {
 	return err
 }
 
-// WalletPassword prompts user to input wallet password when password is not
-// specified from command line
-func WalletPassword(passwd string) []byte {
-	if passwd == "" {
-		tmppasswd, _ := password.GetPassword()
-		return tmppasswd
-	} else {
-		return []byte(passwd)
-	}
-}
-
 func GetPassword(passwd string) []byte {
 	var tmp []byte
 	var err error

--- a/cmd/nknd/nknd.go
+++ b/cmd/nknd/nknd.go
@@ -168,7 +168,7 @@ func nknMain(c *cli.Context) error {
 
 	log.Infof("Node version: %v", config.Version)
 
-	var wallet vault.Wallet
+	var wallet *vault.Wallet
 	var account *vault.Account
 	if config.Parameters.WebGuiCreateWallet {
 		for wallet == nil || account == nil {
@@ -233,7 +233,7 @@ func nknMain(c *cli.Context) error {
 		log.Fatalf("Get or create id error: %v", err)
 	}
 
-	log.Info("current chord ID: ", common.BytesToHexString(id))
+	log.Infof("current chord ID: %x", id)
 
 	conf := &nnet.Config{
 		Transport:        config.Parameters.Transport,
@@ -535,7 +535,7 @@ func GetID(seeds []string, publickey []byte) ([]byte, error) {
 	return nil, fmt.Errorf("failed to get ID from majority of %d seeds", n)
 }
 
-func CreateID(seeds []string, wallet vault.Wallet, regFee, txnFee common.Fixed64) error {
+func CreateID(seeds []string, wallet *vault.Wallet, regFee, txnFee common.Fixed64) error {
 	account, err := wallet.GetDefaultAccount()
 	if err != nil {
 		return err
@@ -586,7 +586,7 @@ func CreateID(seeds []string, wallet vault.Wallet, regFee, txnFee common.Fixed64
 	return errors.New("create ID failed")
 }
 
-func GetOrCreateID(seeds []string, wallet vault.Wallet, regFee, txnFee common.Fixed64) ([]byte, error) {
+func GetOrCreateID(seeds []string, wallet *vault.Wallet, regFee, txnFee common.Fixed64) ([]byte, error) {
 	account, err := wallet.GetDefaultAccount()
 	if err != nil {
 		return nil, err

--- a/common/common.go
+++ b/common/common.go
@@ -53,17 +53,9 @@ func BytesToInt(b []byte) []int {
 	return i
 }
 
-func BytesToHexString(data []byte) string {
-	return hex.EncodeToString(data)
-}
-
-func HexStringToBytes(value string) ([]byte, error) {
-	return hex.DecodeString(value)
-}
-
-func ClearBytes(arr []byte, len int) {
-	for i := 0; i < len; i++ {
-		arr[i] = 0
+func ClearBytes(b []byte) {
+	for i := 0; i < len(b); i++ {
+		b[i] = 0
 	}
 }
 

--- a/crypto/helper.go
+++ b/crypto/helper.go
@@ -1,24 +1,21 @@
 package crypto
 
 import (
-	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/sha256"
 	"errors"
 
-	. "github.com/nknorg/nkn/common"
+	"github.com/nknorg/nkn/common"
 )
 
-func ToAesKey(pwd []byte) []byte {
-	pwdhash := sha256.Sum256(pwd)
-	pwdhash2 := sha256.Sum256(pwdhash[:])
-
-	// Fixme clean the password buffer
-	// ClearBytes(pwd,len(pwd))
-	ClearBytes(pwdhash[:], 32)
-
-	return pwdhash2[:]
+func PasswordHash(password []byte) []byte {
+	passwordhash := sha256.Sum256(password)
+	passwordhash2 := sha256.Sum256(passwordhash[:])
+	passwordhash3 := sha256.Sum256(passwordhash2[:])
+	common.ClearBytes(passwordhash[:])
+	common.ClearBytes(passwordhash2[:])
+	return passwordhash3[:]
 }
 
 func AesEncrypt(plaintext []byte, key []byte, iv []byte) ([]byte, error) {
@@ -26,18 +23,15 @@ func AesEncrypt(plaintext []byte, key []byte, iv []byte) ([]byte, error) {
 	if err != nil {
 		return nil, errors.New("invalid decrypt key")
 	}
-	//blockSize := block.BlockSize()
-	//plaintext = PKCS5Padding(plaintext, blockSize)
-	blockMode := cipher.NewCBCEncrypter(block, iv)
 
 	ciphertext := make([]byte, len(plaintext))
+	blockMode := cipher.NewCBCEncrypter(block, iv)
 	blockMode.CryptBlocks(ciphertext, plaintext)
 
 	return ciphertext, nil
 }
 
 func AesDecrypt(ciphertext []byte, key []byte, iv []byte) ([]byte, error) {
-
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, errors.New("invalid decrypt key")
@@ -53,24 +47,9 @@ func AesDecrypt(ciphertext []byte, key []byte, iv []byte) ([]byte, error) {
 		return nil, errors.New("ciphertext is not a multiple of the block size")
 	}
 
-	blockModel := cipher.NewCBCDecrypter(block, iv)
-
 	plaintext := make([]byte, len(ciphertext))
-	blockModel.CryptBlocks(plaintext, ciphertext)
-	//plaintext = PKCS5UnPadding(plaintext)
+	blockMode := cipher.NewCBCDecrypter(block, iv)
+	blockMode.CryptBlocks(plaintext, ciphertext)
 
 	return plaintext, nil
-}
-
-func PKCS5Padding(src []byte, blockSize int) []byte {
-	padding := blockSize - len(src)%blockSize
-	padtext := bytes.Repeat([]byte{byte(padding)}, padding)
-
-	return append(src, padtext...)
-}
-
-func PKCS5UnPadding(src []byte) []byte {
-	length := len(src)
-	unpadding := int(src[length-1])
-	return src[:(length - unpadding)]
 }

--- a/dashboard/auth/auth.go
+++ b/dashboard/auth/auth.go
@@ -3,32 +3,33 @@ package auth
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
-	. "github.com/nknorg/nkn/common"
 	serviceConfig "github.com/nknorg/nkn/dashboard/config"
 	"github.com/nknorg/nkn/dashboard/helpers"
 	"github.com/nknorg/nkn/util/log"
 	"github.com/nknorg/nkn/vault"
-	"net/http"
-	"strconv"
-	"time"
 )
 
-func verifyPasswordKey(passwordKey []byte, passwordHash []byte, token string) bool {
+func verifyPasswordKey(passwordKey, passwordHash []byte, token string) bool {
 	tick := time.Now().Unix()
 	padding := int64(serviceConfig.UnixRange)
-	pwdData := []byte(BytesToHexString(passwordHash))
+	pwdData := []byte(hex.EncodeToString(passwordHash))
 	hash := sha256.Sum224(pwdData)
 	for i := tick - padding; i < tick+padding; i++ {
-		seedHash := BytesToHexString(helpers.HmacSha256([]byte(BytesToHexString(hash[:])), []byte(token+strconv.FormatInt(i, 10))))
-		hexHash, err := helpers.AesEncrypt(BytesToHexString(hash[:]), seedHash)
+		seedHash := hex.EncodeToString(helpers.HmacSha256([]byte(hex.EncodeToString(hash[:])), []byte(token+strconv.FormatInt(i, 10))))
+		hexHash, err := helpers.AesEncrypt(hex.EncodeToString(hash[:]), seedHash)
 		if err != nil {
 			log.WebLog.Error(err)
 			return false
 		}
-		hexByte, err := HexStringToBytes(hexHash)
+		hexByte, err := hex.DecodeString(hexHash)
 		if err != nil {
 			log.WebLog.Error(err)
 			return false
@@ -49,22 +50,17 @@ func WalletAuth() gin.HandlerFunc {
 			context.AbortWithError(http.StatusUnauthorized, errors.New("401 Unauthorized"))
 			return
 		}
+
 		wallet, exists := context.Get("wallet")
 		if !exists {
 			context.AbortWithError(http.StatusInternalServerError, errors.New("wallet has not been initialized"))
 			return
 		}
 
-		passwordKey, err := HexStringToBytes(auth)
+		passwordKey, err := hex.DecodeString(auth)
 		if err != nil {
 			log.WebLog.Error(err)
 			context.AbortWithError(http.StatusForbidden, err)
-			return
-		}
-		passwordKeyHash, err := HexStringToBytes(wallet.(*vault.WalletImpl).Data.PasswordHash)
-		if err != nil {
-			log.WebLog.Error(err)
-			context.AbortWithError(http.StatusInternalServerError, err)
 			return
 		}
 
@@ -75,7 +71,7 @@ func WalletAuth() gin.HandlerFunc {
 			context.AbortWithError(http.StatusForbidden, errors.New("403 Forbidden"))
 			return
 		}
-		if ok := verifyPasswordKey(passwordKey, passwordKeyHash, token.(string)); !ok {
+		if ok := verifyPasswordKey(passwordKey, wallet.(*vault.Wallet).PasswordHash, token.(string)); !ok {
 			context.AbortWithError(http.StatusForbidden, errors.New("403 Forbidden"))
 			return
 		}

--- a/dashboard/routes/node/status.go
+++ b/dashboard/routes/node/status.go
@@ -1,14 +1,15 @@
 package node
 
 import (
+	"encoding/hex"
 	"encoding/json"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
-	"github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/dashboard/helpers"
 	"github.com/nknorg/nkn/node"
 	"github.com/nknorg/nkn/util/config"
 	"github.com/nknorg/nkn/util/log"
-	"net/http"
 )
 
 func StatusRouter(router *gin.RouterGroup) {
@@ -31,7 +32,7 @@ func StatusRouter(router *gin.RouterGroup) {
 				return
 			}
 			id := context.MustGet("id").([]byte)
-			out["id"] = common.BytesToHexString(id)
+			out["id"] = hex.EncodeToString(id)
 		}
 
 		out["beneficiaryAddr"] = config.Parameters.BeneficiaryAddr

--- a/dashboard/routes/wallet/create.go
+++ b/dashboard/routes/wallet/create.go
@@ -3,6 +3,8 @@ package wallet
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	serviceConfig "github.com/nknorg/nkn/dashboard/config"
 	"github.com/nknorg/nkn/dashboard/helpers"
@@ -10,7 +12,6 @@ import (
 	"github.com/nknorg/nkn/util/log"
 	"github.com/nknorg/nkn/util/password"
 	"github.com/nknorg/nkn/vault"
-	"net/http"
 )
 
 type CreateWalletData struct {
@@ -32,8 +33,8 @@ func WalletCreateRouter(router *gin.RouterGroup) {
 
 		_, exists := context.Get("wallet")
 		if exists {
-			log.WebLog.Error("wallet file exists.")
-			context.AbortWithError(http.StatusInternalServerError, errors.New("wallet file exists."))
+			log.WebLog.Error("Wallet file exists.")
+			context.AbortWithError(http.StatusInternalServerError, errors.New("wallet file exists"))
 			return
 		}
 
@@ -46,23 +47,22 @@ func WalletCreateRouter(router *gin.RouterGroup) {
 			}
 		}
 
-		_, err = vault.NewWallet(config.Parameters.WalletFile, []byte(data.Password), true)
+		_, err = vault.NewWallet(config.Parameters.WalletFile, []byte(data.Password))
 		if err != nil {
-			log.WebLog.Error("create wallet error: ", err)
+			log.WebLog.Error("Create wallet error: ", err)
 			context.AbortWithError(http.StatusInternalServerError, err)
 			return
 		}
 		password.Passwd = data.Password
 		err = password.SavePassword(password.Passwd)
 		if err != nil {
-			log.WebLog.Error("save wallet error: ", err)
+			log.WebLog.Error("Save wallet error: ", err)
 		}
 
 		serviceConfig.Status = serviceConfig.Status | serviceConfig.SERVICE_STATUS_RUNNING
 
 		context.JSON(http.StatusOK, "")
 		return
-
 	})
 
 }

--- a/dashboard/routes/wallet/download.go
+++ b/dashboard/routes/wallet/download.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/nknorg/nkn/dashboard/auth"
 	"github.com/nknorg/nkn/util/log"
 	"github.com/nknorg/nkn/vault"
-	"net/http"
 )
 
 type DownloadWalletData struct {
@@ -21,12 +22,12 @@ func WalletDownloadRouter(router *gin.RouterGroup) {
 
 		wallet, exists := context.Get("wallet")
 		if !exists {
-			log.WebLog.Error("wallet file not exists.")
-			context.AbortWithError(http.StatusInternalServerError, errors.New("wallet file not exists."))
+			log.WebLog.Error("Wallet file not exists.")
+			context.AbortWithError(http.StatusInternalServerError, errors.New("wallet file not exists"))
 			return
 		}
 
-		bytes, err := json.MarshalIndent(&wallet.(*vault.WalletImpl).Data, "", "    ")
+		bytes, err := json.MarshalIndent(&wallet.(*vault.Wallet).WalletData, "", "    ")
 		if err != nil {
 			log.WebLog.Error(err)
 			context.AbortWithError(http.StatusInternalServerError, err)

--- a/dashboard/routes/wallet/open.go
+++ b/dashboard/routes/wallet/open.go
@@ -1,30 +1,15 @@
 package wallet
 
 import (
-	"bytes"
-	"crypto/sha256"
 	"encoding/json"
-	"errors"
-	"fmt"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
-	. "github.com/nknorg/nkn/common"
-	"github.com/nknorg/nkn/crypto"
 	"github.com/nknorg/nkn/dashboard/helpers"
 	"github.com/nknorg/nkn/util/log"
 	"github.com/nknorg/nkn/util/password"
 	"github.com/nknorg/nkn/vault"
-	"net/http"
 )
-
-func verifyPasswordKey(passwordKey []byte, passwordHash []byte) bool {
-	keyHash := sha256.Sum256(passwordKey)
-	if !bytes.Equal(passwordHash, keyHash[:]) {
-		fmt.Println("error: password wrong")
-		return false
-	}
-
-	return true
-}
 
 type OpenWalletData struct {
 	Password string `form:"password" binding:"required"`
@@ -43,19 +28,12 @@ func WalletOpenRouter(router *gin.RouterGroup) {
 
 		wallet, exists := context.Get("wallet")
 		if exists {
-			passwordKey := crypto.ToAesKey([]byte(data.Password))
-			passwordKeyHash, err := HexStringToBytes(wallet.(*vault.WalletImpl).Data.PasswordHash)
+			err = wallet.(*vault.Wallet).VerifyPassword([]byte(data.Password))
 			if err != nil {
 				log.WebLog.Error("open wallet error: ", err)
 				context.AbortWithError(http.StatusForbidden, err)
 				return
 			}
-			if ok := verifyPasswordKey(passwordKey, passwordKeyHash); !ok {
-				log.WebLog.Error("open wallet error: ", errors.New("password wrong"))
-				context.AbortWithError(http.StatusForbidden, errors.New("password wrong"))
-				return
-			}
-
 		} else {
 			password.Passwd = data.Password
 			_, err := vault.GetWallet()
@@ -72,7 +50,6 @@ func WalletOpenRouter(router *gin.RouterGroup) {
 		}
 		context.JSON(http.StatusOK, "")
 		return
-
 	})
 
 }

--- a/dashboard/service.go
+++ b/dashboard/service.go
@@ -21,11 +21,11 @@ import (
 
 var (
 	localNode *node.LocalNode
-	wallet    vault.Wallet
+	wallet    *vault.Wallet
 	id        []byte
 )
 
-func Init(ln *node.LocalNode, w vault.Wallet, d []byte) {
+func Init(ln *node.LocalNode, w *vault.Wallet, d []byte) {
 	if ln != nil {
 		localNode = ln
 		serviceConfig.IsNodeInit = true

--- a/node/localnode.go
+++ b/node/localnode.go
@@ -51,7 +51,7 @@ type LocalNode struct {
 	proposalSubmitted uint32    // Count of localNode submitted proposal
 }
 
-func NewLocalNode(wallet vault.Wallet, nn *nnet.NNet) (*LocalNode, error) {
+func NewLocalNode(wallet *vault.Wallet, nn *nnet.NNet) (*LocalNode, error) {
 	account, err := wallet.GetDefaultAccount()
 	if err != nil {
 		return nil, err

--- a/node/relay.go
+++ b/node/relay.go
@@ -19,12 +19,12 @@ import (
 
 type RelayService struct {
 	sync.Mutex
-	wallet    vault.Wallet
+	wallet    *vault.Wallet
 	localNode *LocalNode
 	porServer *por.PorServer
 }
 
-func NewRelayService(wallet vault.Wallet, localNode *LocalNode) *RelayService {
+func NewRelayService(wallet *vault.Wallet, localNode *LocalNode) *RelayService {
 	service := &RelayService{
 		wallet:    wallet,
 		localNode: localNode,
@@ -362,7 +362,7 @@ func (localNode *LocalNode) SendRelayMessage(srcAddr, destAddr string, payload, 
 	return nil
 }
 
-func MakeSigChainTransaction(wallet vault.Wallet, sigChain []byte) (*transaction.Transaction, error) {
+func MakeSigChainTransaction(wallet *vault.Wallet, sigChain []byte) (*transaction.Transaction, error) {
 	account, err := wallet.GetDefaultAccount()
 	if err != nil {
 		return nil, err

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -2,6 +2,7 @@ package transaction
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
@@ -269,18 +270,18 @@ func (tx *Transaction) GetInfo() ([]byte, error) {
 	tx.Hash()
 	info := &txnInfo{
 		TxType:      tx.UnsignedTx.Payload.GetType().String(),
-		PayloadData: BytesToHexString(tx.UnsignedTx.Payload.GetData()),
+		PayloadData: hex.EncodeToString(tx.UnsignedTx.Payload.GetData()),
 		Nonce:       tx.UnsignedTx.Nonce,
 		Fee:         tx.UnsignedTx.Fee,
-		Attributes:  BytesToHexString(tx.UnsignedTx.Attributes),
+		Attributes:  hex.EncodeToString(tx.UnsignedTx.Attributes),
 		Programs:    make([]programInfo, 0),
 		Hash:        tx.hash.ToHexString(),
 	}
 
 	for _, v := range tx.Programs {
 		pgInfo := &programInfo{}
-		pgInfo.Code = BytesToHexString(v.Code)
-		pgInfo.Parameter = BytesToHexString(v.Parameter)
+		pgInfo.Code = hex.EncodeToString(v.Code)
+		pgInfo.Parameter = hex.EncodeToString(v.Parameter)
 		info.Programs = append(info.Programs, *pgInfo)
 	}
 

--- a/util/address/address.go
+++ b/util/address/address.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/util/log"
 )
 
@@ -44,7 +43,7 @@ func MakeAddressString(pubKey []byte, identifier string) string {
 		result.WriteString(identifier)
 		result.WriteString(".")
 	}
-	result.WriteString(common.BytesToHexString(pubKey))
+	result.WriteString(hex.EncodeToString(pubKey))
 
 	return result.String()
 }

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -462,7 +463,7 @@ func (config *Configuration) verify() error {
 		return errors.New("no GenesisBlockProposer")
 	}
 
-	pk, err := common.HexStringToBytes(config.GenesisBlockProposer)
+	pk, err := hex.DecodeString(config.GenesisBlockProposer)
 	if err != nil {
 		return fmt.Errorf("parse GenesisBlockProposer error: %v", err)
 	}

--- a/util/password/password.go
+++ b/util/password/password.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/nknorg/nkn/common"
-	"github.com/nknorg/nkn/util/config"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/nknorg/nkn/common"
+	"github.com/nknorg/nkn/util/config"
 
 	"github.com/howeyc/gopass"
 )

--- a/vault/account.go
+++ b/vault/account.go
@@ -34,7 +34,12 @@ func NewAccount() (*Account, error) {
 	return account, nil
 }
 
-func NewAccountWithPrivatekey(privateKey []byte) (*Account, error) {
+func NewAccountWithSeed(seed []byte) (*Account, error) {
+	if err := crypto.CheckSeed(seed); err != nil {
+		return nil, err
+	}
+
+	privateKey := crypto.GetPrivateKeyFromSeed(seed)
 	pubKey := crypto.GetPublicKeyFromPrivateKey(privateKey)
 	programHash, err := program.CreateProgramHash(pubKey)
 	if err != nil {

--- a/vault/data.go
+++ b/vault/data.go
@@ -40,7 +40,7 @@ type WalletData struct {
 	Scrypt        *ScryptData
 }
 
-func NewWalletData(account *Account, password, masterKey, iv []byte) (*WalletData, error) {
+func NewWalletData(account *Account, password, masterKey, iv, scryptSalt []byte, scryptN, scryptR, scryptP int) (*WalletData, error) {
 	if len(masterKey) == 0 {
 		masterKey = util.RandomBytes(MasterKeyLength)
 	}
@@ -49,11 +49,27 @@ func NewWalletData(account *Account, password, masterKey, iv []byte) (*WalletDat
 		iv = util.RandomBytes(IVLength)
 	}
 
+	if len(scryptSalt) == 0 {
+		scryptSalt = util.RandomBytes(ScryptSaltLength)
+	}
+
+	if scryptN == 0 {
+		scryptN = ScryptN
+	}
+
+	if scryptR == 0 {
+		scryptR = ScryptR
+	}
+
+	if scryptP == 0 {
+		scryptP = ScryptP
+	}
+
 	scryptData := &ScryptData{
-		Salt: hex.EncodeToString(util.RandomBytes(ScryptSaltLength)),
-		N:    ScryptN,
-		R:    ScryptR,
-		P:    ScryptP,
+		Salt: hex.EncodeToString(scryptSalt),
+		N:    scryptN,
+		R:    scryptR,
+		P:    scryptP,
 	}
 
 	var passwordKey []byte

--- a/vault/data.go
+++ b/vault/data.go
@@ -1,0 +1,184 @@
+package vault
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/nknorg/nkn/common"
+	"github.com/nknorg/nkn/crypto"
+	"github.com/nknorg/nkn/util"
+	"golang.org/x/crypto/scrypt"
+)
+
+const (
+	IVLength                   = 16
+	MasterKeyLength            = 32
+	ScryptSaltLength           = 8
+	ScryptN                    = 1 << 15
+	ScryptR                    = 8
+	ScryptP                    = 1
+	WalletVersion              = 2
+	MinCompatibleWalletVersion = 1
+	MaxCompatibleWalletVersion = 2
+)
+
+type ScryptData struct {
+	Salt string
+	N    int
+	R    int
+	P    int
+}
+
+type WalletData struct {
+	Version       int
+	IV            string
+	MasterKey     string
+	SeedEncrypted string
+	Address       string
+	Scrypt        *ScryptData
+}
+
+func NewWalletData(account *Account, password, masterKey, iv []byte) (*WalletData, error) {
+	if len(masterKey) == 0 {
+		masterKey = util.RandomBytes(MasterKeyLength)
+	}
+
+	if len(iv) == 0 {
+		iv = util.RandomBytes(IVLength)
+	}
+
+	scryptData := &ScryptData{
+		Salt: hex.EncodeToString(util.RandomBytes(ScryptSaltLength)),
+		N:    ScryptN,
+		R:    ScryptR,
+		P:    ScryptP,
+	}
+
+	var passwordKey []byte
+	var err error
+	switch WalletVersion {
+	case 1:
+		passwordKey = PasswordToAesKeyHash(password)
+	case 2:
+		passwordKey, err = PasswordToAesKeyScrypt(password, scryptData)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported wallet version %d", WalletVersion)
+	}
+
+	encryptedMasterKey, err := crypto.AesEncrypt(masterKey, passwordKey, iv)
+	if err != nil {
+		return nil, err
+	}
+
+	seed := crypto.GetSeedFromPrivateKey(account.PrivateKey)
+	encryptedSeed, err := crypto.AesEncrypt(seed, masterKey, iv)
+	if err != nil {
+		return nil, err
+	}
+
+	address, err := account.ProgramHash.ToAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	walletData := &WalletData{
+		Version:       WalletVersion,
+		IV:            hex.EncodeToString(iv),
+		MasterKey:     hex.EncodeToString(encryptedMasterKey),
+		SeedEncrypted: hex.EncodeToString(encryptedSeed),
+		Address:       address,
+		Scrypt:        scryptData,
+	}
+
+	return walletData, nil
+}
+
+func (walletData *WalletData) DecryptMasterKey(password []byte) ([]byte, error) {
+	var passwordKey []byte
+	var err error
+	switch walletData.Version {
+	case 1:
+		passwordKey = PasswordToAesKeyHash(password)
+	case 2:
+		passwordKey, err = PasswordToAesKeyScrypt(password, walletData.Scrypt)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported wallet version %d", walletData.Version)
+	}
+
+	iv, err := hex.DecodeString(walletData.IV)
+	if err != nil {
+		return nil, err
+	}
+
+	encryptedMasterKey, err := hex.DecodeString(walletData.MasterKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return crypto.AesDecrypt(encryptedMasterKey, passwordKey, iv)
+}
+
+func (walletData *WalletData) DecryptAccount(password []byte) (*Account, error) {
+	masterKey, err := walletData.DecryptMasterKey(password)
+	if err != nil {
+		return nil, err
+	}
+
+	encryptedSeed, err := hex.DecodeString(walletData.SeedEncrypted)
+	if err != nil {
+		return nil, err
+	}
+
+	iv, err := hex.DecodeString(walletData.IV)
+	if err != nil {
+		return nil, err
+	}
+
+	seed, err := crypto.AesDecrypt(encryptedSeed, masterKey, iv)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewAccountWithSeed(seed)
+}
+
+func (walletData *WalletData) VerifyPassword(password []byte) error {
+	account, err := walletData.DecryptAccount(password)
+	if err != nil {
+		return err
+	}
+
+	address, err := account.ProgramHash.ToAddress()
+	if err != nil {
+		return err
+	}
+
+	if address != walletData.Address {
+		return errors.New("wrong password")
+	}
+
+	return nil
+}
+
+func PasswordToAesKeyHash(password []byte) []byte {
+	passwordhash := sha256.Sum256(password)
+	passwordhash2 := sha256.Sum256(passwordhash[:])
+	common.ClearBytes(passwordhash[:])
+	return passwordhash2[:]
+}
+
+func PasswordToAesKeyScrypt(password []byte, scryptData *ScryptData) ([]byte, error) {
+	salt, err := hex.DecodeString(scryptData.Salt)
+	if err != nil {
+		return nil, err
+	}
+	return scrypt.Key(password, salt, scryptData.N, scryptData.R, scryptData.P, 32)
+}

--- a/vault/wallet.go
+++ b/vault/wallet.go
@@ -1,13 +1,10 @@
 package vault
 
 import (
-	"bytes"
-	"crypto/rand"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 
-	. "github.com/nknorg/nkn/common"
+	"github.com/nknorg/nkn/common"
 	"github.com/nknorg/nkn/crypto"
 	serviceConfig "github.com/nknorg/nkn/dashboard/config"
 	"github.com/nknorg/nkn/pb"
@@ -18,222 +15,94 @@ import (
 	"github.com/nknorg/nkn/util/password"
 )
 
-const (
-	WalletIVLength             = 16
-	WalletMasterKeyLength      = 32
-	WalletVersion              = 1
-	MinCompatibleWalletVersion = 1
-	MaxCompatibleWalletVersion = 1
-)
-
-type Wallet interface {
-	Sign(txn *transaction.Transaction) error
-	GetAccount(pubKey []byte) (*Account, error)
-	GetDefaultAccount() (*Account, error)
-}
-
-type WalletImpl struct {
-	path      string
-	iv        []byte
-	masterKey []byte
-	account   *Account
-	contract  *program.ProgramContext
+type Wallet struct {
 	*WalletStore
+	PasswordHash []byte
+	account      *Account
+	contract     *program.ProgramContext
 }
 
-func NewWallet(path string, password []byte, needAccount bool) (*WalletImpl, error) {
-	var err error
-	// store init
-	store, err := NewStore(path)
-	if err != nil {
-		return nil, err
-	}
-	// generate password hash
-	passwordKey := crypto.ToAesKey(password)
-	pwdhash := sha256.Sum256(passwordKey)
-	// generate IV
-	iv := make([]byte, WalletIVLength)
-	_, err = rand.Read(iv)
-	if err != nil {
-		return nil, err
-	}
-	// generate master key
-	masterKey := make([]byte, WalletMasterKeyLength)
-	_, err = rand.Read(masterKey)
-	if err != nil {
-		return nil, err
-	}
-	encryptedMasterKey, err := crypto.AesEncrypt(masterKey[:], passwordKey, iv)
-	if err != nil {
-		return nil, err
-	}
-	// persist to store
-	err = store.SaveBasicData(WalletVersion, iv, encryptedMasterKey, pwdhash[:])
+func NewWallet(path string, password []byte) (*Wallet, error) {
+	account, err := NewAccount()
 	if err != nil {
 		return nil, err
 	}
 
-	w := &WalletImpl{
-		path:        path,
-		iv:          iv,
-		masterKey:   masterKey,
-		WalletStore: store,
-	}
-	// generate default account
-	if needAccount {
-		err = w.CreateAccount(nil)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return w, nil
-}
-
-func OpenWallet(path string, password []byte) (*WalletImpl, error) {
-	var err error
-	store, err := LoadStore(path)
+	walletData, err := NewWalletData(account, password, nil, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	if store.Data.Version < MinCompatibleWalletVersion || store.Data.Version > MaxCompatibleWalletVersion {
-		return nil, fmt.Errorf("invalid wallet version %v, should be between %v and %v", store.Data.Version, MinCompatibleWalletVersion, MaxCompatibleWalletVersion)
-	}
-
-	passwordKey := crypto.ToAesKey(password)
-	passwordKeyHash, err := HexStringToBytes(store.Data.PasswordHash)
-	if err != nil {
-		return nil, err
-	}
-	if ok := verifyPasswordKey(passwordKey, passwordKeyHash); !ok {
-		return nil, errors.New("password wrong")
-	}
-	iv, err := HexStringToBytes(store.Data.IV)
-	if err != nil {
-		return nil, err
-	}
-	encryptedMasterKey, err := HexStringToBytes(store.Data.MasterKey)
-	if err != nil {
-		return nil, err
-	}
-	masterKey, err := crypto.AesDecrypt(encryptedMasterKey, passwordKey, iv)
+	walletStore, err := NewWalletStore(path, walletData)
 	if err != nil {
 		return nil, err
 	}
 
-	encryptedSeed, err := HexStringToBytes(store.Data.AccountData.SeedEncrypted)
-	if err != nil {
-		return nil, err
-	}
-	seed, err := crypto.AesDecrypt(encryptedSeed, masterKey, iv)
+	contract, err := program.CreateSignatureProgramContext(account.PubKey())
 	if err != nil {
 		return nil, err
 	}
 
-	privateKey := crypto.GetPrivateKeyFromSeed(seed)
-	if err = crypto.CheckPrivateKey(privateKey); err != nil {
-		return nil, err
-	}
-
-	account, err := NewAccountWithPrivatekey(privateKey)
+	err = walletStore.Save()
 	if err != nil {
 		return nil, err
 	}
 
-	ct, err := program.CreateSignatureProgramContext(account.PubKey())
-	if err != nil {
-		return nil, err
-	}
-
-	return &WalletImpl{
-		path:        path,
-		iv:          iv,
-		masterKey:   masterKey,
-		account:     account,
-		contract:    ct,
-		WalletStore: store,
+	return &Wallet{
+		WalletStore:  walletStore,
+		PasswordHash: crypto.PasswordHash(password),
+		account:      account,
+		contract:     contract,
 	}, nil
 }
 
-func RecoverWallet(path string, password []byte, seedHex string) (*WalletImpl, error) {
-	wallet, err := NewWallet(path, password, false)
-	if err != nil {
-		return nil, errors.New("create new wallet error")
-	}
-	seed, err := HexStringToBytes(seedHex)
-	if err != nil {
-		return nil, err
-	}
-	err = wallet.CreateAccount(seed)
+func OpenWallet(path string, password []byte) (*Wallet, error) {
+	walletStore, err := LoadWalletStore(path)
 	if err != nil {
 		return nil, err
 	}
 
-	return wallet, nil
-}
+	walletData := walletStore.WalletData
 
-func (w *WalletImpl) CreateAccount(seed []byte) error {
-	var account *Account
-	var err error
-	if seed == nil {
-		account, err = NewAccount()
-		if err != nil {
-			return err
-		}
-		seed = crypto.GetSeedFromPrivateKey(account.PrivateKey)
-	} else {
-		if err = crypto.CheckSeed(seed); err != nil {
-			return err
-		}
-		privateKey := crypto.GetPrivateKeyFromSeed(seed)
-		if err = crypto.CheckPrivateKey(privateKey); err != nil {
-			return err
-		}
-		account, err = NewAccountWithPrivatekey(privateKey)
-		if err != nil {
-			return err
-		}
+	if walletData.Version < MinCompatibleWalletVersion || walletData.Version > MaxCompatibleWalletVersion {
+		return nil, fmt.Errorf("invalid wallet version %v, should be between %v and %v", walletData.Version, MinCompatibleWalletVersion, MaxCompatibleWalletVersion)
 	}
 
-	encryptedSeed, err := crypto.AesEncrypt(seed, w.masterKey, w.iv)
+	account, err := walletData.DecryptAccount(password)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	address, err := account.ProgramHash.ToAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	if address != walletData.Address {
+		return nil, errors.New("wrong password")
+	}
+
 	contract, err := program.CreateSignatureProgramContext(account.PubKey())
 	if err != nil {
-		return err
+		return nil, err
 	}
-	err = w.SaveAccountData(account.ProgramHash.ToArray(), encryptedSeed, contract.ToArray())
-	if err != nil {
-		return err
-	}
-	w.account = account
 
-	return nil
+	return &Wallet{
+		WalletStore:  walletStore,
+		PasswordHash: crypto.PasswordHash(password),
+		account:      account,
+		contract:     contract,
+	}, nil
 }
 
-func (w *WalletImpl) GetDefaultAccount() (*Account, error) {
+func (w *Wallet) GetDefaultAccount() (*Account, error) {
 	if w.account == nil {
 		return nil, errors.New("account error")
 	}
 	return w.account, nil
 }
 
-func (w *WalletImpl) GetAccount(pubKey []byte) (*Account, error) {
-	redeemHash, err := program.CreateProgramHash(pubKey)
-	if err != nil {
-		return nil, fmt.Errorf("%v\n%s", err, "[Account] GetAccount redeemhash generated failed")
-	}
-
-	if redeemHash != w.account.ProgramHash {
-		return nil, errors.New("invalid account")
-	}
-
-	return w.account, nil
-}
-
-func (w *WalletImpl) Sign(txn *transaction.Transaction) error {
+func (w *Wallet) Sign(txn *transaction.Transaction) error {
 	contract, err := w.GetContract()
 	if err != nil {
 		return fmt.Errorf("cannot get contract from wallet: %v", err)
@@ -256,46 +125,39 @@ func (w *WalletImpl) Sign(txn *transaction.Transaction) error {
 	return nil
 }
 
-func verifyPasswordKey(passwordKey []byte, passwordHash []byte) bool {
-	keyHash := sha256.Sum256(passwordKey)
-	if !bytes.Equal(passwordHash, keyHash[:]) {
-		fmt.Println("error: password wrong")
-		return false
-	}
-
-	return true
+func (w *Wallet) VerifyPassword(password []byte) error {
+	return w.WalletStore.WalletData.VerifyPassword(password)
 }
 
-func (w *WalletImpl) ChangePassword(oldPassword []byte, newPassword []byte) bool {
-	// check original password
-	oldPasswordKey := crypto.ToAesKey(oldPassword)
-	passwordKeyHash, err := HexStringToBytes(w.Data.PasswordHash)
+func (w *Wallet) ChangePassword(oldPassword, newPassword []byte) error {
+	account, err := w.DecryptAccount(oldPassword)
 	if err != nil {
-		return false
-	}
-	if ok := verifyPasswordKey(oldPasswordKey, passwordKeyHash); !ok {
-		return false
+		return err
 	}
 
-	// encrypt master key with new password
-	newPasswordKey := crypto.ToAesKey(newPassword)
-	newPasswordHash := sha256.Sum256(newPasswordKey)
-	newMasterKey, err := crypto.AesEncrypt(w.masterKey, newPasswordKey, w.iv)
+	address, err := account.ProgramHash.ToAddress()
 	if err != nil {
-		fmt.Println("error: set new password failed")
-		return false
+		return err
 	}
 
-	// update wallet file
-	err = w.SaveBasicData(WalletVersion, w.iv, newMasterKey, newPasswordHash[:])
-	if err != nil {
-		return false
+	if address != w.Address {
+		return errors.New("wrong password")
 	}
 
-	return true
+	w.WalletData, err = NewWalletData(account, newPassword, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	err = w.Save()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
-func (w *WalletImpl) GetContract() (*program.ProgramContext, error) {
+func (w *Wallet) GetContract() (*program.ProgramContext, error) {
 	if w.contract == nil {
 		return nil, errors.New("contract error")
 	}
@@ -303,37 +165,34 @@ func (w *WalletImpl) GetContract() (*program.ProgramContext, error) {
 	return w.contract, nil
 }
 
-func GetWallet() (Wallet, error) {
+func GetWallet() (*Wallet, error) {
 	walletFileName := config.Parameters.WalletFile
-	if !FileExisted(walletFileName) {
+	if !common.FileExisted(walletFileName) {
 		serviceConfig.Status = serviceConfig.Status | serviceConfig.SERVICE_STATUS_NO_WALLET_FILE
 		return nil, fmt.Errorf("wallet file %s does not exist, please create a wallet using nknc", walletFileName)
-	} else {
-		serviceConfig.Status = serviceConfig.Status &^ serviceConfig.SERVICE_STATUS_NO_WALLET_FILE
 	}
+	serviceConfig.Status = serviceConfig.Status &^ serviceConfig.SERVICE_STATUS_NO_WALLET_FILE
 
 	passwd, err := password.GetAccountPassword()
+	defer common.ClearBytes(passwd)
 	if err != nil {
 		serviceConfig.Status = serviceConfig.Status | serviceConfig.SERVICE_STATUS_NO_PASSWORD
 		return nil, fmt.Errorf("get password error: %v", err)
-	} else {
-		serviceConfig.Status = serviceConfig.Status &^ serviceConfig.SERVICE_STATUS_NO_PASSWORD
 	}
+	serviceConfig.Status = serviceConfig.Status &^ serviceConfig.SERVICE_STATUS_NO_PASSWORD
 
 	if (serviceConfig.Status&serviceConfig.SERVICE_STATUS_NO_WALLET_FILE) != 0 && !config.Parameters.AllowEmptyBeneficiaryAddress && config.Parameters.BeneficiaryAddr == "" {
 		serviceConfig.Status = serviceConfig.Status | serviceConfig.SERVICE_STATUS_NO_BENEFICIARY
-		return nil, fmt.Errorf("wait for set beneficiary address.")
-	} else {
-		serviceConfig.Status = serviceConfig.Status &^ serviceConfig.SERVICE_STATUS_NO_BENEFICIARY
+		return nil, fmt.Errorf("wait for set beneficiary address")
 	}
+	serviceConfig.Status = serviceConfig.Status &^ serviceConfig.SERVICE_STATUS_NO_BENEFICIARY
 
 	w, err := OpenWallet(walletFileName, passwd)
 	if err != nil {
 		serviceConfig.Status = serviceConfig.Status | serviceConfig.SERVICE_STATUS_NO_PASSWORD
 		return nil, fmt.Errorf("open wallet error: %v", err)
-	} else {
-		serviceConfig.Status = serviceConfig.Status &^ serviceConfig.SERVICE_STATUS_NO_PASSWORD
 	}
+	serviceConfig.Status = serviceConfig.Status &^ serviceConfig.SERVICE_STATUS_NO_PASSWORD
 	serviceConfig.Status = serviceConfig.Status | serviceConfig.SERVICE_STATUS_RUNNING
 	return w, nil
 }

--- a/vault/wallet.go
+++ b/vault/wallet.go
@@ -28,7 +28,7 @@ func NewWallet(path string, password []byte) (*Wallet, error) {
 		return nil, err
 	}
 
-	walletData, err := NewWalletData(account, password, nil, nil)
+	walletData, err := NewWalletData(account, password, nil, nil, nil, 0, 0, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func (w *Wallet) ChangePassword(oldPassword, newPassword []byte) error {
 		return errors.New("wrong password")
 	}
 
-	w.WalletData, err = NewWalletData(account, newPassword, nil, nil)
+	w.WalletData, err = NewWalletData(account, newPassword, nil, nil, nil, 0, 0, 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Upgrade wallet format: use scrypt as kdf instead of sha256. Also removed redundant fields in wallet.json.

Wallet version is now 2. Version 1 will continue to work, but less secure.

Use `nknc wallet --changepassword` to upgrade to v2 wallet.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
