### PR TITLE
Reduce sigchain cache timeout to reduce relay ram usage (stage 2/2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ GC=GO111MODULE=on go build
 GO_PROXY=https://goproxy.io
 GOFMT=go fmt
 VERSION:=$(shell git describe --abbrev=4 --dirty --always --tags)
-Minversion:=$(shell date)
 BUILD_DIR=build
 BIN_DIR=$(GOOS)-$(GOARCH)
 NKND_BUILD_PARAM=-ldflags "-s -w -X github.com/nknorg/nkn/util/config.Version=$(VERSION)"

--- a/common/serialization/serialize.go
+++ b/common/serialization/serialize.go
@@ -1,7 +1,6 @@
 package serialization
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"io"
@@ -254,12 +253,6 @@ func WriteUint64(writer io.Writer, val uint64) error {
 	binary.LittleEndian.PutUint64(p[:], val)
 	_, err := writer.Write(p[:])
 	return err
-}
-
-func ToArray(data SerializableData) []byte {
-	b_buf := new(bytes.Buffer)
-	data.Serialize(b_buf)
-	return b_buf.Bytes()
 }
 
 //**************************************************************************

--- a/por/porserver.go
+++ b/por/porserver.go
@@ -20,13 +20,12 @@ import (
 )
 
 const (
-	// TODO: reduce sigChainElemCacheExpiration and srcSigChainCacheExpiration in next version when most nodes support pin sigchain
-	sigChainElemCacheExpiration          = 10 * config.ConsensusTimeout
+	sigChainElemCacheExpiration          = 10 * time.Second
 	sigChainElemCachePinnedExpiration    = 10 * config.ConsensusTimeout
-	sigChainElemCacheCleanupInterval     = config.ConsensusDuration
-	srcSigChainCacheExpiration           = 10 * config.ConsensusTimeout
+	sigChainElemCacheCleanupInterval     = 2 * time.Second
+	srcSigChainCacheExpiration           = 10 * time.Second
 	srcSigChainCachePinnedExpiration     = 10 * config.ConsensusTimeout
-	srcSigChainCacheCleanupInterval      = config.ConsensusDuration
+	srcSigChainCacheCleanupInterval      = 2 * time.Second
 	destSigChainElemCacheExpiration      = 10 * config.ConsensusTimeout
 	destSigChainElemCacheCleanupInterval = config.ConsensusDuration
 	finalizedBlockCacheExpiration        = 10 * config.ConsensusTimeout

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -191,11 +191,6 @@ func (tx *Transaction) GetMessage() []byte {
 	return signature.GetHashData(tx)
 }
 
-func (tx *Transaction) ToArray() []byte {
-	dt, _ := tx.Marshal()
-	return dt
-}
-
 func (tx *Transaction) Hash() Uint256 {
 	if tx.hash == nil {
 		d := signature.GetHashData(tx)


### PR DESCRIPTION
This PR is the second stage in reducing relay RAM usage when most nodes have merged #702

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
