### PR TITLE
Return different rpc response when node is pruning or generate id

### DIFF
--- a/api/common/interfaces.go
+++ b/api/common/interfaces.go
@@ -332,7 +332,12 @@ func getNeighbor(s Serverer, params map[string]interface{}) map[string]interface
 // params: {}
 // return: {"resultOrData":<result>|<error data>, "error":<errcode>}
 func getNodeState(s Serverer, params map[string]interface{}) map[string]interface{} {
-	return respPacking(SUCCESS, s.GetNetNode())
+	n := s.GetNetNode()
+	if n == nil {
+		// will be recovered by handler
+		panic(ErrNullID)
+	}
+	return respPacking(SUCCESS, n)
 }
 
 // setDebugInfo sets log level


### PR DESCRIPTION
User can tell whether a node is pruning db or generating id from the response of get node state rpc.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
