### PR TITLE
Fix incorrect BVS state after NanoPay txn is removed from BVS

### DIFF
--- a/chain/pool/txpool.go
+++ b/chain/pool/txpool.go
@@ -308,7 +308,7 @@ func (tp *TxnPool) processTx(txn *transaction.Transaction) error {
 		// sigchain txn should not be added to txn pool
 		return nil
 	case pb.NANO_PAY_TYPE:
-		if err := tp.blockValidationState.VerifyTransactionWithBlock(txn, 0); err != nil {
+		if err := tp.blockValidationState.VerifyTransactionWithBlock(txn, chain.DefaultLedger.Store.GetHeight()+1); err != nil {
 			tp.blockValidationState.Reset()
 			return err
 		}
@@ -319,7 +319,7 @@ func (tp *TxnPool) processTx(txn *transaction.Transaction) error {
 			if err := tp.CleanBlockValidationState([]*transaction.Transaction{oldTxn}); err != nil {
 				return err
 			}
-			if err := tp.blockValidationState.VerifyTransactionWithBlock(txn, 0); err != nil {
+			if err := tp.blockValidationState.VerifyTransactionWithBlock(txn, chain.DefaultLedger.Store.GetHeight()+1); err != nil {
 				tp.blockValidationState.Reset()
 				return err
 			}
@@ -349,7 +349,7 @@ func (tp *TxnPool) processTx(txn *transaction.Transaction) error {
 				return errors.New("nonce is not continuous")
 			}
 
-			if err := tp.blockValidationState.VerifyTransactionWithBlock(txn, 0); err != nil {
+			if err := tp.blockValidationState.VerifyTransactionWithBlock(txn, chain.DefaultLedger.Store.GetHeight()+1); err != nil {
 				tp.blockValidationState.Reset()
 				return err
 			}

--- a/chain/txValidator.go
+++ b/chain/txValidator.go
@@ -582,7 +582,6 @@ func (bvs *BlockValidationState) GetSubscribersWithMeta(topic string) map[string
 
 // VerifyTransactionWithBlock verifies a transaction with current transaction pool in memory
 func (bvs *BlockValidationState) VerifyTransactionWithBlock(txn *transaction.Transaction, height uint32) (e error) {
-	//1.check weather have duplicate transaction.
 	if _, exist := bvs.txnlist[txn.Hash()]; exist {
 		return errors.New("[VerifyTransactionWithBlock] duplicate transaction exist in block")
 	} else {
@@ -595,7 +594,6 @@ func (bvs *BlockValidationState) VerifyTransactionWithBlock(txn *transaction.Tra
 		}()
 	}
 
-	//3.check issue amount
 	payload, err := transaction.Unpack(txn.UnsignedTx.Payload)
 	if err != nil {
 		return errors.New("[VerifyTransactionWithBlock] payload unpack error")
@@ -804,6 +802,10 @@ func (bvs *BlockValidationState) VerifyTransactionWithBlock(txn *transaction.Tra
 
 func (bvs *BlockValidationState) CleanSubmittedTransactions(txns []*transaction.Transaction) error {
 	for _, txn := range txns {
+		if _, exist := bvs.txnlist[txn.Hash()]; !exist {
+			continue
+		}
+
 		delete(bvs.txnlist, txn.Hash())
 
 		payload, err := transaction.Unpack(txn.UnsignedTx.Payload)
@@ -903,7 +905,7 @@ func (bvs *BlockValidationState) RefreshBlockValidationState(txns []*transaction
 	bvs.initBlockValidationState()
 	errMap := make(map[common.Uint256]error, 0)
 	for _, tx := range txns {
-		if err := bvs.VerifyTransactionWithBlock(tx, 0); err != nil {
+		if err := bvs.VerifyTransactionWithBlock(tx, DefaultLedger.Store.GetHeight()+1); err != nil {
 			errMap[tx.Hash()] = err
 		}
 	}


### PR DESCRIPTION
This PR fixes the incorrect bvs balance state after nanopay txn is removed from bvs.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/nknorg/nkn#contributing).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).
- [x] Code has been written according to [NKN-Golang-Style-Guide](https://github.com/nknorg/nkn/wiki/NKN-Golang-Style-Guide)

### Extra information
Any extra information related to this pull request.
