### PR TITLE
Disable live pruning by default

### DIFF
--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -402,12 +402,14 @@ func (cs *ChainStore) SaveBlock(b *block.Block, fastAdd bool) error {
 	}
 	cs.headerCache.AddHeaderToCache(b.Header)
 
-	switch config.Parameters.StatePruningMode {
-	case "lowmem":
-		err = cs.PruneStatesLowMemory(false)
-		if err != nil {
-			log.Errorf("Pruning error: %v", err)
-			return err
+	if config.LivePruning {
+		switch config.Parameters.StatePruningMode {
+		case "lowmem":
+			err = cs.PruneStatesLowMemory(false)
+			if err != nil {
+				log.Errorf("Pruning error: %v", err)
+				return err
+			}
 		}
 	}
 

--- a/cmd/nknd/nknd.go
+++ b/cmd/nknd/nknd.go
@@ -44,7 +44,7 @@ import (
 )
 
 const (
-	NetVersionNum = 15 // This is temporary and will be removed soon after mainnet is stabilized
+	NetVersionNum = 16 // This is temporary and will be removed soon after mainnet is stabilized
 )
 
 var (

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -74,6 +74,7 @@ const (
 	MaxClientMessageSize         = 4 * 1024 * 1024
 	MinNameRegistrationFee       = 10 * common.StorageFactor
 	DefaultNameDuration          = 365 * 24 * 60 * 60 / int(ConsensusDuration/time.Second)
+	LivePruning                  = false
 )
 
 const (


### PR DESCRIPTION
This might help solving the save block slow issues on slow devices

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
