### PR TITLE
Prune ledger during first syncing to reduce syncing disk usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ crossbuild: web
 	mkdir -p $(BUILD_DIR)/$(BIN_DIR)
 	${MAKE} build
 	cp config.mainnet.json $(BUILD_DIR)/$(BIN_DIR)/default.json
-	cp -a certs $(BUILD_DIR)/$(BIN_DIR)/certs
 	@cp -a dashboard/web/dist $(BUILD_DIR)/$(BIN_DIR)/web
 ifeq ($(GOOS), windows)
 	echo "IF NOT EXIST config.json COPY default.json config.json" > $(BUILD_DIR)/$(BIN_DIR)/start-gui.bat

--- a/chain/ledgerStore.go
+++ b/chain/ledgerStore.go
@@ -10,7 +10,7 @@ import (
 
 // ILedgerStore provides func with store package.
 type ILedgerStore interface {
-	SaveBlock(b *block.Block, fastAdd bool) error
+	SaveBlock(b *block.Block, pruning bool) error
 	GetBlock(hash common.Uint256) (*block.Block, error)
 	GetBlockByHeight(height uint32) (*block.Block, error)
 	GetBlockHash(height uint32) (common.Uint256, error)

--- a/chain/store/store.go
+++ b/chain/store/store.go
@@ -385,7 +385,7 @@ func (cs *ChainStore) persist(b *block.Block) error {
 	return nil
 }
 
-func (cs *ChainStore) SaveBlock(b *block.Block, fastAdd bool) error {
+func (cs *ChainStore) SaveBlock(b *block.Block, pruning bool) error {
 	err := cs.persist(b)
 	if err != nil {
 		log.Errorf("error to persist block: %v", err)
@@ -402,7 +402,7 @@ func (cs *ChainStore) SaveBlock(b *block.Block, fastAdd bool) error {
 	}
 	cs.headerCache.AddHeaderToCache(b.Header)
 
-	if config.LivePruning {
+	if pruning {
 		switch config.Parameters.StatePruningMode {
 		case "lowmem":
 			err = cs.PruneStatesLowMemory(false)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -299,7 +299,7 @@ func (consensus *Consensus) saveAcceptedBlock(electedBlockHash common.Uint256) e
 		if syncState == pb.WAIT_FOR_SYNCING {
 			consensus.localNode.SetSyncState(pb.PERSIST_FINISHED)
 		}
-		err = chain.DefaultLedger.Blockchain.AddBlock(block, false)
+		err = chain.DefaultLedger.Blockchain.AddBlock(block, config.LivePruning)
 		if err != nil {
 			return err
 		}
@@ -395,7 +395,7 @@ func (consensus *Consensus) saveBlocksAcceptedDuringSync(startHeight uint32) err
 			return err
 		}
 
-		err = chain.DefaultLedger.Blockchain.AddBlock(block, false)
+		err = chain.DefaultLedger.Blockchain.AddBlock(block, config.LivePruning)
 		if err != nil {
 			return err
 		}

--- a/node/localnode.go
+++ b/node/localnode.go
@@ -233,6 +233,7 @@ func (localNode *LocalNode) SetSyncState(s pb.SyncState) bool {
 	log.Infof("Set sync state to %s", s.String())
 	changed := localNode.Node.SetSyncState(s)
 	if changed && s == pb.PERSIST_FINISHED {
+		config.SyncPruning = config.LivePruning
 		localNode.verifyNeighbors()
 	}
 	return changed

--- a/node/syncblock.go
+++ b/node/syncblock.go
@@ -511,7 +511,7 @@ func (localNode *LocalNode) syncBlocks(startHeight, stopHeight, syncBlocksBatchS
 				return false
 			}
 
-			err := chain.DefaultLedger.Blockchain.AddBlock(block, false)
+			err := chain.DefaultLedger.Blockchain.AddBlock(block, config.SyncPruning)
 			if err != nil {
 				return false
 			}

--- a/util/config/config.go
+++ b/util/config/config.go
@@ -75,7 +75,6 @@ const (
 	MaxClientMessageSize           = 4 * 1024 * 1024
 	MinNameRegistrationFee         = 10 * common.StorageFactor
 	DefaultNameDuration            = 365 * 24 * 60 * 60 / int(ConsensusDuration/time.Second)
-	LivePruning                    = false
 )
 
 const (
@@ -87,6 +86,8 @@ const (
 )
 
 var (
+	SyncPruning      = true
+	LivePruning      = false
 	Debug            = false
 	PprofPort        = "127.0.0.1:8080"
 	ShortHashSalt    = util.RandomBytes(32)
@@ -161,9 +162,9 @@ var (
 )
 
 var (
+	gateway                      *portmapper.PortMapper
 	Version                      string
 	SkipNAT                      bool
-	gateway                      *portmapper.PortMapper
 	ConfigFile                   string
 	LogPath                      string
 	ChainDBPath                  string
@@ -224,7 +225,7 @@ var (
 		PasswordFile:                 "",
 		StatePruningMode:             "lowmem",
 		RecentStateCount:             1024,
-		MinPruningCompactHeights:     4096,
+		MinPruningCompactHeights:     32768,
 		RPCRateLimit:                 1024,
 		RPCRateBurst:                 4096,
 		SyncBlockHeaderRateLimit:     8192,


### PR DESCRIPTION
This will greatly reduce the max disk usage during first syncing

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
