### PR TITLE
Remove legacy certs from docker build workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,12 +180,8 @@ random password saved to `/nkn/data/wallet.pswd` if not exists on nknd launch.
 
 #### `certs/`
 
-The default `certs/` can be found in repo, in release version, and in docker
-image (under `/nkn/`). You should use the default one unless you want to use
-your own custom domain and certificates for RPC and websockets.
-
-The docker container will copy the default certificates to `/nkn/data/certs/` if
-not exists on nknd launch.
+`nknd` uses Let's Encrypt to apply and renew TLS certificate and put in into
+`cert/` directory.
 
 #### Data and Logs
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,6 @@ RUN apk --no-cache add ca-certificates
 COPY --from=builder /nkn/nknd /nkn/
 COPY --from=builder /nkn/nknc /nkn/
 COPY --from=builder /nkn/config.mainnet.json /nkn/
-COPY --from=builder /nkn/certs /nkn/certs
 COPY --from=builder /nkn/web /nkn/web
 COPY --from=builder /nkn/docker/entrypoint.sh /nkn/
 RUN ln -s /nkn/nknd /nkn/nknc /usr/local/bin/

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,7 +3,6 @@ set -e
 
 if [ "$1" == "nknd" ]; then
   ! [ -s web ] && echo "Copying web directory..." && cp -R ../web web
-  ! [ -s certs ] && echo "Copying default certs..." && cp -R ../certs certs
   ! [ -s config.json ] && echo "Copying default config.json..." && cp /nkn/config.mainnet.json config.json
   if echo "$@" | grep -q -v " --web-gui-create-wallet"; then
     ! [ -s wallet.json ] && ! [ -s wallet.pswd ] && echo "Creating wallet.pswd..." && head -c 1024 /dev/urandom | tr -dc A-Za-z0-9 | head -c 32 > wallet.pswd && echo >> wallet.pswd


### PR DESCRIPTION

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
