### PR TITLE
Start consensus timer using proposal received time

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/nknorg/nkn/v2/block"
 	"github.com/nknorg/nkn/v2/chain"
 	"github.com/nknorg/nkn/v2/common"
 	"github.com/nknorg/nkn/v2/config"
@@ -33,7 +32,7 @@ type Consensus struct {
 	elections     common.Cache
 
 	proposalLock   sync.RWMutex
-	proposalChan   chan *block.Block
+	proposalChan   chan *proposalInfo
 	expectedHeight uint32
 
 	nextConsensusHeightLock sync.Mutex
@@ -51,7 +50,7 @@ func NewConsensus(account *vault.Account, localNode *node.LocalNode) (*Consensus
 		localNode:           localNode,
 		elections:           common.NewGoCache(cacheExpiration, cacheCleanupInterval),
 		proposals:           common.NewGoCache(cacheExpiration, cacheCleanupInterval),
-		proposalChan:        make(chan *block.Block, proposalChanLen),
+		proposalChan:        make(chan *proposalInfo, proposalChanLen),
 		requestProposalChan: make(chan *requestProposalInfo, requestProposalChanLen),
 		mining:              chain.NewBuiltinMining(account, txnCollector),
 		txnCollector:        txnCollector,
@@ -248,7 +247,7 @@ func (consensus *Consensus) setExpectedHeight(expectedHeight uint32) {
 		}
 
 		consensus.expectedHeight = expectedHeight
-		consensus.proposalChan = make(chan *block.Block, proposalChanLen)
+		consensus.proposalChan = make(chan *proposalInfo, proposalChanLen)
 	}
 	consensus.proposalLock.Unlock()
 }


### PR DESCRIPTION
This PR prevents slow IO node from delayed consensus timer

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
