### PR TITLE
Remove per topic sub count limit

### DIFF
--- a/chain/blockvalidator.go
+++ b/chain/blockvalidator.go
@@ -635,11 +635,10 @@ func VerifyTransactionWithLedger(txn *transaction.Transaction, height uint32) er
 		if err != nil {
 			return err
 		}
-		if !subscribed {
+		if !subscribed && config.MaxSubscriptionsCount > 0 {
 			subscriptionCount := DefaultLedger.Store.GetSubscribersCount(pld.Topic, pld.Bucket)
-			maxSubscriptionCount := config.MaxSubscriptionsCount
-			if subscriptionCount >= maxSubscriptionCount {
-				return fmt.Errorf("subscription count to %s can't be more than %d", pld.Topic, maxSubscriptionCount)
+			if subscriptionCount >= config.MaxSubscriptionsCount {
+				return fmt.Errorf("subscription count to %s can't be more than %d", pld.Topic, config.MaxSubscriptionsCount)
 			}
 		}
 	case pb.PayloadType_UNSUBSCRIBE_TYPE:

--- a/chain/bvs.go
+++ b/chain/bvs.go
@@ -237,9 +237,11 @@ func (bvs *BlockValidationState) VerifyTransactionWithBlock(txn *transaction.Tra
 		subscriptionCount := bvs.subscriptionCount[topic]
 		subscriptionCountChange := bvs.subscriptionCountChange[topic]
 		if !subscribed {
-			ledgerSubscriptionCount := DefaultLedger.Store.GetSubscribersCount(topic, bucket)
-			if ledgerSubscriptionCount+subscriptionCount+subscriptionCountChange >= config.MaxSubscriptionsCount {
-				return errors.New("[VerifyTransactionWithBlock] subscription limit exceeded in block")
+			if config.MaxSubscriptionsCount > 0 {
+				ledgerSubscriptionCount := DefaultLedger.Store.GetSubscribersCount(topic, bucket)
+				if ledgerSubscriptionCount+subscriptionCount+subscriptionCountChange >= config.MaxSubscriptionsCount {
+					return errors.New("[VerifyTransactionWithBlock] subscription limit exceeded in block")
+				}
 			}
 			bvs.subscriptionCountChange[topic]++
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -135,7 +135,7 @@ var (
 		heights: []uint32{245000, 0},
 		values:  []int32{400000, 65535},
 	}
-	MaxSubscriptionsCount = 100000
+	MaxSubscriptionsCount = 0 // 0 for unlimited
 	MaxGenerateIDTxnHash  = HeightDependentUint256{
 		heights: []uint32{245000, 0},
 		values: []common.Uint256{


### PR DESCRIPTION
This change will greatly accelerate subscribe operation when number of subscribers per topic is large.

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [x] Feature (Breaking change)
- [ ] Documentation Improvement
