### PR TITLE
Remove web during build only if yarn is installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ help:  ## Show available options with this Makefile
 	@grep -F -h "##" $(MAKEFILE_LIST) | grep -v grep | awk 'BEGIN { FS = ":.*?##" }; { printf "%-15s  %s\n", $$1,$$2 }'
 
 web: $(shell find dashboard/web -type f -not -path "dashboard/web/node_modules/*" -not -path "dashboard/web/dist/*" -not -path "dashboard/web/.nuxt/*")
-	@rm -rf web
-	-@cd dashboard/web && yarn install && yarn build && cp -a ./dist ../../web
+	-@cd dashboard/web && yarn install && yarn build && rm -rf ../../web && cp -a ./dist ../../web
 
 .PHONY: build
 build: web


### PR DESCRIPTION
Fix the bug that `web` is deleted if yarn is not installed

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
