### PR TITLE
Init log module in nknc to prevent panic

### DIFF
--- a/cmd/nknc/nknc.go
+++ b/cmd/nknc/nknc.go
@@ -27,6 +27,11 @@ func init() {
 }
 
 func main() {
+	err := log.Init()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	defer func() {
 		if r := recover(); r != nil {
 			log.Fatalf("Panic: %+v", r)


### PR DESCRIPTION
This PR fix the bug that log module is not initialized and could cause panic if used.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
