### PR TITLE
Fix http json rpc request body not closed

### DIFF
--- a/api/httpjson/RPCserver.go
+++ b/api/httpjson/RPCserver.go
@@ -92,6 +92,7 @@ func (s *RPCServer) Handle(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("content-type", "application/json;charset=utf-8")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	if r.Method == "POST" {
+		defer r.Body.Close()
 		// read the body of the request
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {


### PR DESCRIPTION
This PR fixes the bug that RPC request body might not be closed

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
