### PR TITLE
Add length limit for sigchain bit shift

### DIFF
--- a/cmd/nknd/nknd.go
+++ b/cmd/nknd/nknd.go
@@ -46,7 +46,7 @@ import (
 )
 
 const (
-	NetVersionNum = 20 // This is temporary and will be removed soon after mainnet is stabilized
+	NetVersionNum = 21 // This is temporary and will be removed soon after mainnet is stabilized
 )
 
 var (

--- a/config/config.go
+++ b/config/config.go
@@ -161,6 +161,10 @@ var (
 		heights: []uint32{1200000, 0},
 		values:  []bool{false, true},
 	}
+	SigChainBitShiftMaxLength = HeightDependentInt32{
+		heights: []uint32{2543000, 0},
+		values:  []int32{14, 0},
+	}
 )
 
 var (

--- a/por/porpackage.go
+++ b/por/porpackage.go
@@ -109,7 +109,7 @@ func NewPorPackage(txn *transaction.Transaction, shouldVerify bool) (*PorPackage
 	}
 
 	txHash := txn.Hash()
-	sigHash, err := sigChain.SignatureHash()
+	sigHash, err := sigChain.SignatureHash(height)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change will prevent very long sigchain to gain additional advantage caused by sigchain bit shift

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [x] Feature (Breaking change)
- [ ] Documentation Improvement
