### PR TITLE
Increase requestTxnChanLen

### DIFF
--- a/node/transaction.go
+++ b/node/transaction.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	requestTxnSaltSize                  = 32
-	requestTxnChanLen                   = 1000
+	requestTxnChanLen                   = 10000
 	requestSigChainTxnWorkerPoolSize    = 10
 	requestSigChainCacheExpiration      = 50 * config.ConsensusTimeout
 	requestSigChainCacheCleanupInterval = config.ConsensusDuration


### PR DESCRIPTION
This could fix `request txn chan full` error when for nodes with lots of slow neighbors

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
