### PR TITLE
Add result cache to getsubscriberscount rpc

### DIFF
--- a/api/common/cache.go
+++ b/api/common/cache.go
@@ -1,0 +1,8 @@
+package common
+
+import (
+	"github.com/nknorg/nkn/v2/common"
+	"github.com/nknorg/nkn/v2/config"
+)
+
+var rpcResultCache = common.NewGoCache(config.ConsensusDuration, config.ConsensusDuration/4)

--- a/api/common/interfaces.go
+++ b/api/common/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net"
 	"strings"
 
@@ -771,7 +772,18 @@ func getSubscribersCount(s Serverer, params map[string]interface{}) map[string]i
 		}
 	}
 
+	key := []byte(fmt.Sprintf("%s-%d-%s", topic, int(bucket), string(subscriberHashPrefix)))
+
+	if v, ok := rpcResultCache.Get(key); ok {
+		if count, ok := v.(int); ok {
+			return respPacking(errcode.SUCCESS, count)
+		}
+	}
+
 	count := chain.DefaultLedger.Store.GetSubscribersCount(topic, uint32(bucket), subscriberHashPrefix)
+
+	rpcResultCache.Set(key, count)
+
 	return respPacking(errcode.SUCCESS, count)
 }
 


### PR DESCRIPTION
This change will make node to cache getsubscriberscount rpc result which changes slowly (only when a new block is produced).

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
