### PR TITLE
Add connTime to neighbor/chord rpc response 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/itchyny/base58-go v0.0.5
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/nknorg/consequential v0.0.0-20190823093205-a45aff4a218a
-	github.com/nknorg/nnet v0.0.0-20210516000534-f80d3763d1bd
+	github.com/nknorg/nnet v0.0.0-20220112093001-f125c811090c
 	github.com/nknorg/portmapper v0.0.0-20200114081049-1c03cdccc283
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/nknorg/consequential v0.0.0-20190823093205-a45aff4a218a h1:DXTCQnVV2E
 github.com/nknorg/consequential v0.0.0-20190823093205-a45aff4a218a/go.mod h1:H7XeI/XOPpWVmqM+ScT75RLMn7jWnlZDwHRahSxNxo0=
 github.com/nknorg/go-nat v1.0.1 h1:4dFK0oDyqkIE0it03Y4pMgBQpl1Y0mrYHEp+j/nZ910=
 github.com/nknorg/go-nat v1.0.1/go.mod h1:dblX1Ac2j08rTUGs5CKCAfjHGN5eDFhbeqt2rccSP3Y=
-github.com/nknorg/nnet v0.0.0-20210516000534-f80d3763d1bd h1:JsgqFbUrJ+j6+Ys3MqhmPmjlJSWz707RAYjenpMqXGY=
-github.com/nknorg/nnet v0.0.0-20210516000534-f80d3763d1bd/go.mod h1:4DHEQEMhlRGIKGSyhATdjeusdqaHafDatadtpeHBpvI=
+github.com/nknorg/nnet v0.0.0-20220112093001-f125c811090c h1:jPM6SupswGGsecysALiL3bjXTW1JTLqxquVj8845Wq4=
+github.com/nknorg/nnet v0.0.0-20220112093001-f125c811090c/go.mod h1:4DHEQEMhlRGIKGSyhATdjeusdqaHafDatadtpeHBpvI=
 github.com/nknorg/portmapper v0.0.0-20200114081049-1c03cdccc283 h1:uS3/DvxCbi0zZau66ggQAgEjyGmql2mj77UQFgumq1I=
 github.com/nknorg/portmapper v0.0.0-20200114081049-1c03cdccc283/go.mod h1:dL4PQJ4670oTO6LqvkjrBQEkD+iMiOYjlKRBBw55Csg=
 github.com/nrdcg/auroradns v1.0.1/go.mod h1:y4pc0i9QXYlFCWrhWrUSIETnZgrf4KuwjDIWmmXo3JI=

--- a/node/info.go
+++ b/node/info.go
@@ -60,11 +60,10 @@ func (crn *ChordRemoteNodeInfo) MarshalJSON() ([]byte, error) {
 	out["roundTripTime"] = crn.remoteNode.GetRoundTripTime() / time.Millisecond
 	out["protocolVersion"] = nodeData.ProtocolVersion
 
+	out["connTime"] = 0
 	nbr := crn.localNode.getNeighborByNNetNode(crn.remoteNode)
 	if nbr != nil {
 		out["connTime"] = time.Since(nbr.Node.startTime) / time.Second
-	} else {
-		out["connTime"] = 0
 	}
 
 	return json.Marshal(out)

--- a/node/localnode.go
+++ b/node/localnode.go
@@ -43,9 +43,8 @@ type LocalNode struct {
 
 	mu                sync.RWMutex
 	syncOnce          *sync.Once
-	relayMessageCount uint64    // count how many messages node has relayed since start
-	startTime         time.Time // Time of localNode init
-	proposalSubmitted uint32    // Count of localNode submitted proposal
+	relayMessageCount uint64 // count how many messages node has relayed since start
+	proposalSubmitted uint32 // Count of localNode submitted proposal
 }
 
 func NewLocalNode(wallet *vault.Wallet, nn *nnet.NNet) (*LocalNode, error) {
@@ -97,7 +96,6 @@ func NewLocalNode(wallet *vault.Wallet, nn *nnet.NNet) (*LocalNode, error) {
 		syncBlockLimiter:    rate.NewLimiter(rate.Limit(config.Parameters.SyncBlockRateLimit), int(config.Parameters.SyncBlockRateBurst)),
 		messageHandlerStore: newMessageHandlerStore(),
 		nnet:                nn,
-		startTime:           time.Now(),
 	}
 
 	localNode.relayer = NewRelayService(wallet, localNode)
@@ -185,7 +183,7 @@ func (localNode *LocalNode) MarshalJSON() ([]byte, error) {
 	}
 
 	out["height"] = localNode.GetHeight()
-	out["uptime"] = time.Since(localNode.startTime).Truncate(time.Second).Seconds()
+	out["uptime"] = time.Since(localNode.Node.startTime) / time.Second
 	out["version"] = config.Version
 	out["relayMessageCount"] = localNode.GetRelayMessageCount()
 	if config.Parameters.MiningDebug {

--- a/node/node.go
+++ b/node/node.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/nknorg/nkn/v2/crypto"
@@ -16,6 +17,7 @@ type Node struct {
 	*nnetpb.Node
 	*pb.NodeData
 	publicKey []byte
+	startTime time.Time
 
 	sync.RWMutex
 	syncState           pb.SyncState
@@ -50,7 +52,7 @@ func (n *Node) MarshalJSON() ([]byte, error) {
 		return nil, err
 	}
 
-	out["publicKey"] = hex.EncodeToString(n.NodeData.PublicKey)
+	out["publicKey"] = hex.EncodeToString(n.GetPublicKey())
 	out["syncState"] = n.GetSyncState().String()
 
 	return json.Marshal(out)
@@ -66,6 +68,7 @@ func NewNode(nnetNode *nnetpb.Node, nodeData *pb.NodeData) (*Node, error) {
 		Node:      nnetNode,
 		NodeData:  nodeData,
 		publicKey: nodeData.PublicKey,
+		startTime: time.Now(),
 		syncState: pb.SyncState_WAIT_FOR_SYNCING,
 	}
 

--- a/node/remotenode.go
+++ b/node/remotenode.go
@@ -38,6 +38,7 @@ func (remoteNode *RemoteNode) MarshalJSON() ([]byte, error) {
 	out["height"] = remoteNode.GetHeight()
 	out["isOutbound"] = remoteNode.nnetNode.IsOutbound
 	out["roundTripTime"] = remoteNode.nnetNode.GetRoundTripTime() / time.Millisecond
+	out["connTime"] = time.Since(remoteNode.Node.startTime) / time.Second
 
 	return json.Marshal(out)
 }


### PR DESCRIPTION
This PR add connTime field to get neighbors and get chord ring rpc response

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
