### PR TITLE
Remove darwin/386 and add darwin/arm64 arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ all: ## Build binaries for all available architectures
 	${MAKE} crossbuild GOOS=linux GOARCH=mips
 	${MAKE} crossbuild GOOS=linux GOARCH=mipsle
 	${MAKE} crossbuild GOOS=darwin GOARCH=amd64
-	${MAKE} crossbuild GOOS=darwin GOARCH=386
+	${MAKE} crossbuild GOOS=darwin GOARCH=arm64
 	${MAKE} crossbuild GOOS=windows GOARCH=amd64 EXT=.exe
 	${MAKE} crossbuild GOOS=windows GOARCH=386 EXT=.exe
 


### PR DESCRIPTION
darwin/386 is no longer supported in Go 1.17

### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement
