### PR TITLE
Fix: check on symbol flag in nknc and typo in txvalidator

### DIFF
--- a/chain/txvalidator/txvalidator.go
+++ b/chain/txvalidator/txvalidator.go
@@ -264,7 +264,7 @@ func CheckTransactionPayload(txn *transaction.Transaction, height uint32) error 
 			return err
 		}
 		if !match {
-			return fmt.Errorf("name %s should start with a letter, contain a-z0-9 and have length 3-9", pld.Name)
+			return fmt.Errorf("symbol %s should start with a letter, contain a-z0-9 and have length 3-9", pld.Symbol)
 		}
 
 		if pld.TotalSupply < 0 {

--- a/cmd/nknc/asset/asset.go
+++ b/cmd/nknc/asset/asset.go
@@ -79,7 +79,7 @@ func assetAction(c *cli.Context) error {
 		}
 
 		symbol := c.String("symbol")
-		if name == "" {
+		if symbol == "" {
 			fmt.Println("asset symbol is required with [--symbol]")
 			return nil
 		}


### PR DESCRIPTION
### Type (put an `x` where ever applicable)
- [ ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

not a bug really. just a small fix.