### PR TITLE
remove duplicate code within 'chain/trie/pruning.go'

### DIFF
--- a/chain/trie/pruning.go
+++ b/chain/trie/pruning.go
@@ -218,68 +218,60 @@ func (ref *RefCounts) Prune(hash common.Uint256, inMemory bool) error {
 	return nil
 }
 
+// decrement retrieves and decrements the ref.counts for the given node
+// returns false if counter reached zero, otherwise true
+func (ref *RefCounts) decrement(n node, inMemory bool) bool {
+	hash, _ := n.cache()
+	hs, _ := common.Uint256ParseFromBytes(hash)
+	count, ok := ref.counts[hs]
+	if !inMemory {
+		if !ok {
+			v, err := ref.trie.db.Get(db.TrieRefCountKey(hash))
+			if err == nil {
+				count = binary.LittleEndian.Uint32(v)
+				ref.counts[hs] = count
+			} else {
+				log.Fatal("Trie get error: %v", err)
+			}
+		}
+	}
+	if count == 0 {
+		log.Fatalf("RefCount cannot be zero, %v", hs.ToHexString())
+	}
+
+	if count > 1 {
+		ref.counts[hs] = count - 1
+		return true
+	}
+	return false
+}
+
+func (ref *RefCounts) delete(n node, inMemory bool) bool {
+	hash, _ := n.cache()
+	hs, _ := common.Uint256ParseFromBytes(hash)
+
+	delete(ref.counts, hs)
+	ref.trie.db.BatchDelete(db.TrieNodeKey(hash))
+	if !inMemory {
+		ref.trie.db.BatchDelete(db.TrieRefCountKey(hash))
+	}
+	return false
+}
+
 func (ref *RefCounts) prune(n node, inMemory bool) error {
 	switch n := n.(type) {
 	case *shortNode:
-		hash, _ := n.cache()
-		hs, _ := common.Uint256ParseFromBytes(hash)
-		count, ok := ref.counts[hs]
-		if !inMemory {
-			if !ok {
-				v, err := ref.trie.db.Get(db.TrieRefCountKey(hash))
-				if err == nil {
-					count = binary.LittleEndian.Uint32(v)
-					ref.counts[hs] = count
-				} else {
-					log.Fatal("Trie get error: %v", err)
-				}
-			}
-		}
-		if count == 0 {
-			log.Fatalf("RefCount cannot be zero, %v", hs.ToHexString())
-		}
-
-		if count > 1 {
-			ref.counts[hs] = count - 1
+		if ref.decrement(n, inMemory) {
 			return nil
 		}
-
-		delete(ref.counts, hs)
-		ref.trie.db.BatchDelete(db.TrieNodeKey(hash))
-		if !inMemory {
-			ref.trie.db.BatchDelete(db.TrieRefCountKey(hash))
-		}
+		ref.delete(n, inMemory)
 		return ref.prune(n.Val, inMemory)
 
 	case *fullNode:
-		hash, _ := n.cache()
-		hs, _ := common.Uint256ParseFromBytes(hash)
-		count, ok := ref.counts[hs]
-		if !inMemory {
-			if !ok {
-				v, err := ref.trie.db.Get(db.TrieRefCountKey(hash))
-				if err == nil {
-					count = binary.LittleEndian.Uint32(v)
-					ref.counts[hs] = count
-				} else {
-					log.Fatal("Trie get error: %v", err)
-				}
-			}
-		}
-		if count == 0 {
-			log.Fatalf("RefCount cannot be zero, %v", hs.ToHexString())
-		}
-
-		if count > 1 {
-			ref.counts[hs] = count - 1
+		if ref.decrement(n, inMemory) {
 			return nil
 		}
-
-		delete(ref.counts, hs)
-		ref.trie.db.BatchDelete(db.TrieNodeKey(hash))
-		if !inMemory {
-			ref.trie.db.BatchDelete(db.TrieRefCountKey(hash))
-		}
+		ref.delete(n, inMemory)
 		for i := 0; i < LenOfChildrenNodes; i++ {
 			if n.Children[i] != nil {
 				if err := ref.prune(n.Children[i], inMemory); err != nil {
@@ -287,8 +279,8 @@ func (ref *RefCounts) prune(n node, inMemory bool) error {
 				}
 			}
 		}
-
 		return nil
+
 	case hashNode:
 		hs, _ := common.Uint256ParseFromBytes(n)
 		count, ok := ref.counts[hs]


### PR DESCRIPTION
introduce closure function decrementRefCount for reuse this can be further refactored, though the effort can soon become too high

re #919 

(note that the generated diffs make it very difficult to review. It's better to place old/new side by side I guess.

## How to Not do it

This PR showcases how to **NOT do it**.

Though the interaction with the core-developer @yilunzhang leads to results, the effort is too high.

### Wrongs

* The PR is a `WIP` (Work In Progress), and thus changing during review
* The commits were squashed far too early
  * The diff is very difficult to review 

### Rights

* Closing this PR, and following up with a "fresh" one, with many commits, easier to review
* The new PR can later serve as a demo "how to do it right"

Follow-up PR: #922