### PR TITLE
Rework 'chain/trie/pruning.go' to reduce duplication - chunk 1

### DIFF
--- a/chain/trie/pruning.go
+++ b/chain/trie/pruning.go
@@ -283,11 +283,12 @@ func (ref *RefCounts) prune(n node, inMemory bool) error {
 
 		return nil
 	case hashNode:
-		hs, _ := common.Uint256ParseFromBytes(n)
+		hash := n
+		hs, _ := common.Uint256ParseFromBytes(hash)
 		count, ok := ref.counts[hs]
 		if !inMemory {
 			if !ok {
-				v, err := ref.trie.db.Get(db.TrieRefCountKey(n))
+				v, err := ref.trie.db.Get(db.TrieRefCountKey(hash))
 				if err == nil {
 					count = binary.LittleEndian.Uint32(v)
 					ref.counts[hs] = count

--- a/chain/trie/pruning.go
+++ b/chain/trie/pruning.go
@@ -218,9 +218,11 @@ func (ref *RefCounts) Prune(hs common.Uint256, inMemory bool) error {
 	return nil
 }
 
-// nodeRefHashHs returns hash and hs relevant for node RefCount processing
-func (ref *RefCounts) nodeRefHashHs(n node) (hash hashNode, hs common.Uint256) {
+// refCountsIndex returns the RefCounts index for a given node
+// n.cache() is used for short/full nodes, hashNode itself for hashNode types
+func (ref *RefCounts) refCountsIndex(n node) (hs common.Uint256) {
 
+	var hash hashNode
 	switch n := n.(type) {
 	case *shortNode:
 	case *fullNode:
@@ -238,7 +240,8 @@ func (ref *RefCounts) nodeRefHashHs(n node) (hash hashNode, hs common.Uint256) {
 // returns true if counter was decremented, else false
 // raises an error if counter cannot be retrieved or is 0
 func (ref *RefCounts) decrement(n node, inMemory bool) bool {
-	hash, hs := ref.nodeRefHashHs(n)
+	hs := ref.refCountsIndex(n)
+	hash := hs.ToArray()
 	count, ok := ref.counts[hs]
 	if !inMemory {
 		if !ok {
@@ -263,7 +266,8 @@ func (ref *RefCounts) decrement(n node, inMemory bool) bool {
 }
 
 func (ref *RefCounts) delete(n node, inMemory bool) {
-	hash, hs := ref.nodeRefHashHs(n)
+	hs := ref.refCountsIndex(n)
+	hash := hs.ToArray()
 	delete(ref.counts, hs)
 	ref.trie.db.BatchDelete(db.TrieNodeKey(hash))
 	if !inMemory {

--- a/chain/trie/pruning.go
+++ b/chain/trie/pruning.go
@@ -297,26 +297,7 @@ func (ref *RefCounts) prune(n node, inMemory bool) error {
 
 		return nil
 	case hashNode:
-		hash := n
-		hs, _ := common.Uint256ParseFromBytes(hash)
-		count, ok := ref.counts[hs]
-		if !inMemory {
-			if !ok {
-				v, err := ref.trie.db.Get(db.TrieRefCountKey(hash))
-				if err == nil {
-					count = binary.LittleEndian.Uint32(v)
-					ref.counts[hs] = count
-				} else {
-					log.Fatal("Trie get error: %v", err)
-				}
-			}
-		}
-		if count == 0 {
-			log.Fatalf("RefCount cannot be zero, %v", hs.ToHexString())
-		}
-
-		if count > 1 {
-			ref.counts[hs] = count - 1
+		if ref.decrement(n, inMemory) {
 			return nil
 		}
 

--- a/chain/trie/pruning.go
+++ b/chain/trie/pruning.go
@@ -85,8 +85,8 @@ func (ref *RefCounts) LengthOfCounts() int {
 	return len(ref.counts)
 }
 
-func (ref *RefCounts) CreateRefCounts(hash common.Uint256, inMemory, persistIntermediate bool) error {
-	root, err := ref.trie.resolveHash(hash.ToArray(), true)
+func (ref *RefCounts) CreateRefCounts(hs common.Uint256, inMemory, persistIntermediate bool) error {
+	root, err := ref.trie.resolveHash(hs.ToArray(), true)
 	if err != nil {
 		return err
 	}
@@ -203,8 +203,8 @@ func (ref *RefCounts) createRefCounts(n node, inMemory, persistIntermediate bool
 	return nil
 }
 
-func (ref *RefCounts) Prune(hash common.Uint256, inMemory bool) error {
-	root, err := ref.trie.resolveHash(hash.ToArray(), true)
+func (ref *RefCounts) Prune(hs common.Uint256, inMemory bool) error {
+	root, err := ref.trie.resolveHash(hs.ToArray(), true)
 	if err != nil {
 		return err
 	}
@@ -371,8 +371,8 @@ func (ref *RefCounts) NeedReset() (bool, error) {
 	return ref.trie.db.Has(db.TrieRefCountNeedResetKey())
 }
 
-func (ref *RefCounts) Verify(hash common.Uint256) error {
-	root, err := ref.trie.resolveHash(hash.ToArray(), false)
+func (ref *RefCounts) Verify(hsRoot common.Uint256) error {
+	root, err := ref.trie.resolveHash(hsRoot.ToArray(), false)
 	if err != nil {
 		return err
 	}
@@ -385,8 +385,8 @@ func (ref *RefCounts) Verify(hash common.Uint256) error {
 	}
 
 	hs := ref.trie.Hash()
-	if hash.CompareTo(hs) != 0 {
-		return fmt.Errorf("state root not equal: %v, %v", hash.ToHexString(), hs.ToHexString())
+	if hsRoot.CompareTo(hs) != 0 {
+		return fmt.Errorf("state root not equal: %v, %v", hsRoot.ToHexString(), hs.ToHexString())
 	}
 
 	return nil

--- a/chain/trie/pruning.go
+++ b/chain/trie/pruning.go
@@ -219,8 +219,8 @@ func (ref *RefCounts) Prune(hash common.Uint256, inMemory bool) error {
 }
 
 func (ref *RefCounts) prune(n node, inMemory bool) error {
-	switch n := n.(type) {
-	case *shortNode:
+
+	decrementRefCount := func() bool {
 		hash, _ := n.cache()
 		hs, _ := common.Uint256ParseFromBytes(hash)
 		count, ok := ref.counts[hs]
@@ -241,44 +241,27 @@ func (ref *RefCounts) prune(n node, inMemory bool) error {
 
 		if count > 1 {
 			ref.counts[hs] = count - 1
-			return nil
+			return true
 		}
 
 		delete(ref.counts, hs)
 		ref.trie.db.BatchDelete(db.TrieNodeKey(hash))
 		if !inMemory {
 			ref.trie.db.BatchDelete(db.TrieRefCountKey(hash))
+		}
+		return false
+	}
+
+	switch n := n.(type) {
+	case *shortNode:
+		if decrementRefCount() {
+			return nil
 		}
 		return ref.prune(n.Val, inMemory)
 
 	case *fullNode:
-		hash, _ := n.cache()
-		hs, _ := common.Uint256ParseFromBytes(hash)
-		count, ok := ref.counts[hs]
-		if !inMemory {
-			if !ok {
-				v, err := ref.trie.db.Get(db.TrieRefCountKey(hash))
-				if err == nil {
-					count = binary.LittleEndian.Uint32(v)
-					ref.counts[hs] = count
-				} else {
-					log.Fatal("Trie get error: %v", err)
-				}
-			}
-		}
-		if count == 0 {
-			log.Fatalf("RefCount cannot be zero, %v", hs.ToHexString())
-		}
-
-		if count > 1 {
-			ref.counts[hs] = count - 1
+		if decrementRefCount() {
 			return nil
-		}
-
-		delete(ref.counts, hs)
-		ref.trie.db.BatchDelete(db.TrieNodeKey(hash))
-		if !inMemory {
-			ref.trie.db.BatchDelete(db.TrieRefCountKey(hash))
 		}
 		for i := 0; i < LenOfChildrenNodes; i++ {
 			if n.Children[i] != nil {


### PR DESCRIPTION
(re #919)
(#921 showed how to not do it.)

This PR reworks 'chain/trie/pruning.go'. This is not a strict refactoring, because the functionality will change, though only slightly. The context is "reduce duplication".

But as `Refactoring` means `zero functional change`, this here is called `Rework`.

The commit history is kept to showcase additionally the wrong steps. Additionally, the commits can be reviewed one by one, which is usually easier.

## General Review Rules

(why at it, let's produce some rules)

* Make review comments in context (via the `commits`/`Files changed` ui on github)
* Let the executer decide how to proceed (instead of micromanaging the process)
* do not review whilst having super-high quality standards - except those are already applied to the overall code (or at least the code surrounding your review)
* Chunks of Work (not everything must go into one PR)
