### PR TITLE
Add websocket session connectTime to avoid deleting cached message too early

### DIFF
--- a/api/websocket/server/server.go
+++ b/api/websocket/server/server.go
@@ -246,7 +246,7 @@ func (ws *WsServer) registryMethod() {
 		go func() {
 			messages := ws.messageBuffer.PopMessages(clientID)
 			for _, message := range messages {
-				ws.sendInboundRelayMessage(message)
+				ws.sendInboundRelayMessage(message, true)
 			}
 		}()
 
@@ -617,7 +617,7 @@ func (ws *WsServer) startCheckingWrongClients() {
 
 func (ws *WsServer) sendInboundRelayMessageToClient(v interface{}) {
 	if msg, ok := v.(*pb.Relay); ok {
-		ws.sendInboundRelayMessage(msg)
+		ws.sendInboundRelayMessage(msg, true)
 	} else {
 		log.Error("Decode relay message failed")
 	}

--- a/api/websocket/session/session.go
+++ b/api/websocket/session/session.go
@@ -25,7 +25,8 @@ type Session struct {
 	wsLock sync.Mutex
 	ws     *websocket.Conn
 
-	Challenge []byte // client auth, authorization challenge
+	Challenge   []byte    // client auth, authorization challenge
+	connectTime time.Time // The time which the session is established.
 }
 
 func (s *Session) GetSessionId() string {
@@ -87,6 +88,7 @@ func (s *Session) SetClient(chordID, pubKey []byte, addrStr *string, isTls bool)
 	s.clientPubKey = pubKey
 	s.clientAddrStr = addrStr
 	s.isTlsClient = isTls
+	s.connectTime = time.Now()
 }
 
 func (s *Session) isClient() bool {
@@ -142,4 +144,10 @@ func (s *Session) UpdateLastReadTime() {
 	s.Lock()
 	s.lastReadTime = time.Now()
 	s.Unlock()
+}
+
+func (s *Session) GetConnectTime() time.Time {
+	s.RLock()
+	defer s.RUnlock()
+	return s.connectTime
 }


### PR DESCRIPTION
1. Add websocket session a member `connectTime` ;
2. Set connectTime when session `setClient` ;
3. When pop `messageDeliveredCache` message, check session `connectTime` to avoid deleting the message too early.