### PR TITLE
Provide UnmarshalJSON() for common.uint160

### DIFF
--- a/common/uint160.go
+++ b/common/uint160.go
@@ -89,9 +89,21 @@ func IsValidHexAddr(s []byte) bool {
 	return false
 }
 
-func (f Uint160) MarshalJSON() ([]byte, error) {
+func (f *Uint160) MarshalJSON() ([]byte, error) {
 	str, err := f.ToAddress()
 	return []byte("\"" + str + "\""), err
+}
+
+func (f *Uint160) UnmarshalJSON(in []byte) (err error) {
+	if len(in) < 2 {
+		return errors.New("[Common]: Uint160UnmarshalJSON err, len < 2")
+	}
+	temp, err := ToScriptHash(string(in[1 : len(in)-1]))
+	if err != nil {
+		return err
+	}
+	f.SetBytes(temp.ToArray())
+	return nil
 }
 
 func (f *Uint160) ToAddress() (string, error) {

--- a/common/uint160_test.go
+++ b/common/uint160_test.go
@@ -1,0 +1,72 @@
+package common
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+// NKN address: NKNPkGps7i6yye6W2qSVsQUgiyqxWHEoTRby
+// ToHexString(): 867ff0ca31905faec269949de37d27773ba7394e
+const NKNADDRESS = "\"NKNPkGps7i6yye6W2qSVsQUgiyqxWHEoTRby\""
+const NKNADDRESS_HEX = "867ff0ca31905faec269949de37d27773ba7394e"
+
+func TestMarshalJSON(t *testing.T) {
+	// Create instance of Uint160
+	f := new(Uint160)
+
+	dat, err := hex.DecodeString(NKNADDRESS_HEX)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.SetBytes(dat)
+
+	// Expected value after Marshalling
+	expected := []byte(NKNADDRESS)
+
+	bytes, err := f.MarshalJSON()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !bytesEqual(bytes, expected) {
+		t.Fatalf("Expected %v, got %v", expected, bytes)
+	}
+
+	// TODO: If possible, create a scenario where ToAddress returns an error
+	// and verify that MarshalJSON also returns this error.
+}
+
+func TestUnmarshalJSON(t *testing.T) {
+	// Input for unmarshalling
+	input := []byte(NKNADDRESS)
+
+	f := new(Uint160)
+	err := f.UnmarshalJSON(input)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Verify that f has been updated correctly
+	expected, err := hex.DecodeString(NKNADDRESS_HEX)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytesEqual(f.ToArray(), expected) {
+		t.Fatalf("Expected %v, got %v", expected, f.ToArray())
+	}
+
+	// TODO: If possible, create a scenario where ToScriptHash returns an error
+	// and verify that UnmarshalJSON also returns this error.
+}
+
+func bytesEqual(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
fixes error `json: cannot unmarshal string into Go struct field Account.ProgramHash of type common.Uint160` in case `nkn.Account` struct is to be unmarshalled.