### PR TITLE
Change default sync mode from full to light

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -324,7 +324,7 @@ var (
 		SyncBlockHeaderRateBurst:     32768,
 		SyncBlockRateLimit:           256,
 		SyncBlockRateBurst:           1024,
-		SyncMode:                     "full",
+		SyncMode:                     "light",
 		MaxRollbackBlocks:            180,
 		ClientMsgCacheSize:           0,
 		GenesisBlockProposer:         "a0309f8280ca86687a30ca86556113a253762e40eb884fc6063cad2b1ebd7de5",


### PR DESCRIPTION
## Summary
Changes the default sync mode from "full" to "light" to improve the default node experience.

## Changes
- Modified `config/config.go` to set default `SyncMode` to "light" instead of "full"

## Benefits
- Faster blockchain synchronization for new nodes
- Reduced storage requirements
- Better default user experience for node operators

## Backward Compatibility
- Existing nodes with explicit sync mode configurations are not affected
- Users can still override via config file or `--sync` command line flag
- All existing sync modes (full, fast, light) remain supported

## Test Plan
- [x] Verified the change compiles successfully
- [x] Confirmed sync mode validation accepts "light" as valid
- [x] Tested that default configuration returns "light"
- [x] Verified `IsLightSync()` and `IsFastSync()` methods work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)